### PR TITLE
Resolve analyser build order issue

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -31,7 +31,9 @@ jobs:
         dotnet-version: 9.0.x
     - name: Restore dependencies
       run: dotnet restore
-    - name: Build
+    - name: Build analyser project first
+      run: dotnet build rbkApiModules.Analysers/rbkApiModules.Analysers/rbkApiModules.Analysers.csproj --no-restore
+    - name: Build remaining projects
       run: dotnet build --no-restore
     - name: Test
       run: |


### PR DESCRIPTION
<!-- Resolve CS0006 build error by pre-building the analyser project in the CI workflow. -->

The `PaintingProjectsManagement.Features.Paints.Tests` project directly references the `rbkApiModules.Analysers.dll`, requiring the analyser project to be built first. The workflow is updated to build the analyser project separately before the main solution build.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-92f959e7-b1bc-43d7-878b-b0720c08ba91) · [Cursor](https://cursor.com/background-agent?bcId=bc-92f959e7-b1bc-43d7-878b-b0720c08ba91)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)