### PR TITLE
fix: enforce tenant isolation on project update

### DIFF
--- a/back/PaintingProjectsManagement.Features.Projects/UseCases/Commands/UpdateProject.cs
+++ b/back/PaintingProjectsManagement.Features.Projects/UseCases/Commands/UpdateProject.cs
@@ -79,6 +79,7 @@ public class UpdateProject : IEndpoint
         public async Task<CommandResponse> HandleAsync(Request request, CancellationToken cancellationToken)
         {
             var project = await _context.Set<Project>()
+                .Where(x => x.TenantId == request.Identity.Tenant)
                 .Include(x => x.Steps)
                 .FirstAsync(x => x.Id == request.Id, cancellationToken);
 


### PR DESCRIPTION
## Summary
- ensure UpdateProject handler filters by tenant id before modifying project data

## Testing
- `/root/dotnet9/dotnet test PaintingProjectsManagement.Features.Projects.Tests` *(fails: Metadata file 'rbkApiModules.Analysers.dll' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_689bad3a651c8328b2bbf0be123ecc78