### PR TITLE
Add integration outbox and materials sync

### DIFF
--- a/back/PaintingProjectsManagement.Api/Program.cs
+++ b/back/PaintingProjectsManagement.Api/Program.cs
@@ -50,6 +50,9 @@ public class Program
 
         // Events infrastructure registrations
         builder.Services.AddSingleton<IEventTypeRegistry>(sp => new ReflectionEventTypeRegistry(AppDomain.CurrentDomain.GetAssemblies()));
+        builder.Services.AddSingleton<IIntegrationSubscriberRegistry, IntegrationSubscriberRegistry>();
+        builder.Services.AddScoped<IIntegrationOutbox, IntegrationOutbox>();
+        builder.Services.AddScoped<IIntegrationDeliveryScheduler, IntegrationDeliveryScheduler>();
         builder.Services.Configure<OutboxOptions>(opts =>
         {
             opts.BatchSize = 50;
@@ -58,11 +61,12 @@ public class Program
             opts.ResolveDbContext = sp => sp.GetRequiredService<DatabaseContext>();
         });
 
-        // TODO: move to the library builder with the possibility to disable it with startup options
         builder.Services.AddHostedService<OutboxDispatcher>();
+        builder.Services.AddHostedService<IntegrationDispatcher>();
 
         // Register domain-to-integration event handlers for Materials
         builder.Services.AddMaterialsIntegrationHandlers();
+        builder.Services.AddProjectsIntegrationConsumers();
 
         builder.Services.AddRbkApiCoreSetup(options => options
              .EnableBasicAuthenticationHandler()

--- a/back/PaintingProjectsManagement.Features.Materials/Integrations/Handlers/MaterialDeletedHandler.cs
+++ b/back/PaintingProjectsManagement.Features.Materials/Integrations/Handlers/MaterialDeletedHandler.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using PaintingProjectsManagement.Features.Materials.Abstractions;
 using rbkApiModules.Commons.Core;
 
@@ -7,13 +5,13 @@ namespace PaintingProjectsManagement.Features.Materials;
 
 public sealed class MaterialDeletedHandler : IEventHandler<MaterialDeleted>
 {
-    private readonly IServiceScopeFactory _scopeFactory;
-    private readonly IOptions<OutboxOptions> _outboxOptions;
+    private readonly IIntegrationOutbox _outbox;
+    private readonly IIntegrationDeliveryScheduler _scheduler;
 
-    public MaterialDeletedHandler(IServiceScopeFactory scopeFactory, IOptions<OutboxOptions> outboxOptions)
+    public MaterialDeletedHandler(IIntegrationOutbox outbox, IIntegrationDeliveryScheduler scheduler)
     {
-        _scopeFactory = scopeFactory;
-        _outboxOptions = outboxOptions;
+        _outbox = outbox;
+        _scheduler = scheduler;
     }
 
     public async Task Handle(EventEnvelope<MaterialDeleted> envelope, CancellationToken cancellationToken)
@@ -28,28 +26,8 @@ public sealed class MaterialDeletedHandler : IEventHandler<MaterialDeleted>
             envelope.EventId.ToString()
         );
 
-        var payload = JsonEventSerializer.Serialize(integrationEnvelope);
-
-        using var scope = _scopeFactory.CreateScope();
-        var dbContext = _outboxOptions.Value.ResolveDbContext!(scope.ServiceProvider);
-
-        dbContext.Set<OutboxMessage>().Add(new OutboxMessage
-        {
-            Id = integrationEnvelope.EventId,
-            Name = integrationEnvelope.Name,
-            Version = integrationEnvelope.Version,
-            TenantId = integrationEnvelope.TenantId,
-            Username = integrationEnvelope.Username,
-            OccurredUtc = integrationEnvelope.OccurredUtc,
-            CorrelationId = integrationEnvelope.CorrelationId,
-            CausationId = integrationEnvelope.CausationId,
-            Payload = payload,
-            CreatedUtc = DateTime.UtcNow,
-            ProcessedUtc = null,
-            Attempts = 0
-        });
-
-        await dbContext.SaveChangesAsync(cancellationToken);
+        var eventId = _outbox.Enqueue(integrationEnvelope);
+        await _scheduler.SeedDeliveriesAsync(eventId, integrationEnvelope.Name, integrationEnvelope.Version, cancellationToken);
     }
 }
 

--- a/back/PaintingProjectsManagement.Features.Projects/Database/MaterialLocalCopyConfig.cs
+++ b/back/PaintingProjectsManagement.Features.Projects/Database/MaterialLocalCopyConfig.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace PaintingProjectsManagement.Features.Projects;
+
+public class MaterialLocalCopyConfig : IEntityTypeConfiguration<MaterialLocalCopy>
+{
+    public void Configure(EntityTypeBuilder<MaterialLocalCopy> builder)
+    {
+        builder.ToTable("projects.materials_local_copy");
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Name).IsRequired().HasMaxLength(100);
+        builder.Property(x => x.Unit).IsRequired().HasMaxLength(50);
+        builder.Property(x => x.PricePerUnit).IsRequired();
+        builder.Property(x => x.UpdatedUtc).IsRequired();
+    }
+}

--- a/back/PaintingProjectsManagement.Features.Projects/Integrations/Handlers/MaterialCreatedConsumer.cs
+++ b/back/PaintingProjectsManagement.Features.Projects/Integrations/Handlers/MaterialCreatedConsumer.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using PaintingProjectsManagement.Features.Materials.Abstractions;
+using rbkApiModules.Commons.Core;
+
+namespace PaintingProjectsManagement.Features.Projects;
+
+public class MaterialCreatedConsumer : IIntegrationEventHandler<MaterialCreatedV1>
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IOptions<OutboxOptions> _options;
+
+    public MaterialCreatedConsumer(IServiceScopeFactory scopeFactory, IOptions<OutboxOptions> options)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options;
+    }
+
+    public async Task Handle(EventEnvelope<MaterialCreatedV1> envelope, CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = _options.Value.ResolveDbContext!(scope.ServiceProvider);
+        var e = envelope.Event;
+
+        var entity = await db.Set<MaterialLocalCopy>().FindAsync(new object[] { e.MaterialId }, ct);
+        if (entity == null)
+        {
+            entity = new MaterialLocalCopy { Id = e.MaterialId };
+            db.Set<MaterialLocalCopy>().Add(entity);
+        }
+
+        entity.Name = e.Name;
+        entity.Unit = e.PackageContentUnit;
+        entity.PricePerUnit = e.PackagePriceAmount / (e.PackageContentAmount == 0 ? 1 : e.PackageContentAmount);
+        entity.UpdatedUtc = DateTime.UtcNow;
+
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/back/PaintingProjectsManagement.Features.Projects/Integrations/Handlers/MaterialDeletedConsumer.cs
+++ b/back/PaintingProjectsManagement.Features.Projects/Integrations/Handlers/MaterialDeletedConsumer.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using PaintingProjectsManagement.Features.Materials.Abstractions;
+using rbkApiModules.Commons.Core;
+
+namespace PaintingProjectsManagement.Features.Projects;
+
+public class MaterialDeletedConsumer : IIntegrationEventHandler<MaterialDeletedV1>
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IOptions<OutboxOptions> _options;
+
+    public MaterialDeletedConsumer(IServiceScopeFactory scopeFactory, IOptions<OutboxOptions> options)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options;
+    }
+
+    public async Task Handle(EventEnvelope<MaterialDeletedV1> envelope, CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = _options.Value.ResolveDbContext!(scope.ServiceProvider);
+        var entity = await db.Set<MaterialLocalCopy>().FindAsync(new object[] { envelope.Event.MaterialId }, ct);
+        if (entity != null)
+        {
+            db.Remove(entity);
+            await db.SaveChangesAsync(ct);
+        }
+    }
+}

--- a/back/PaintingProjectsManagement.Features.Projects/Integrations/Handlers/MaterialUpdatedConsumer.cs
+++ b/back/PaintingProjectsManagement.Features.Projects/Integrations/Handlers/MaterialUpdatedConsumer.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using PaintingProjectsManagement.Features.Materials.Abstractions;
+using rbkApiModules.Commons.Core;
+
+namespace PaintingProjectsManagement.Features.Projects;
+
+public class MaterialUpdatedConsumer : IIntegrationEventHandler<MaterialPackageContentChanged>
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IOptions<OutboxOptions> _options;
+
+    public MaterialUpdatedConsumer(IServiceScopeFactory scopeFactory, IOptions<OutboxOptions> options)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options;
+    }
+
+    public async Task Handle(EventEnvelope<MaterialPackageContentChanged> envelope, CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = _options.Value.ResolveDbContext!(scope.ServiceProvider);
+        var e = envelope.Event;
+        var entity = await db.Set<MaterialLocalCopy>().FindAsync(new object[] { e.MaterialId }, ct);
+        if (entity == null)
+        {
+            entity = new MaterialLocalCopy { Id = e.MaterialId };
+            db.Set<MaterialLocalCopy>().Add(entity);
+        }
+
+        entity.Name = e.Name;
+        entity.Unit = e.PackageContentUnit;
+        entity.PricePerUnit = e.PackagePriceAmount / (e.PackageContentAmount == 0 ? 1 : e.PackageContentAmount);
+        entity.UpdatedUtc = DateTime.UtcNow;
+
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/back/PaintingProjectsManagement.Features.Projects/Integrations/ProjectsIntegrationBuilder.cs
+++ b/back/PaintingProjectsManagement.Features.Projects/Integrations/ProjectsIntegrationBuilder.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.DependencyInjection;
+using PaintingProjectsManagement.Features.Materials.Abstractions;
+using rbkApiModules.Commons.Core;
+
+namespace PaintingProjectsManagement.Features.Projects;
+
+public static class ProjectsIntegrationBuilder
+{
+    public static IServiceCollection AddProjectsIntegrationConsumers(this IServiceCollection services)
+    {
+        services.AddScoped<IIntegrationEventHandler<MaterialCreatedV1>, MaterialCreatedConsumer>();
+        services.AddScoped<IIntegrationEventHandler<MaterialDeletedV1>, MaterialDeletedConsumer>();
+        services.AddScoped<IIntegrationEventHandler<MaterialPackageContentChanged>, MaterialUpdatedConsumer>();
+        return services;
+    }
+}

--- a/back/PaintingProjectsManagement.Features.Projects/Models/MaterialLocalCopy.cs
+++ b/back/PaintingProjectsManagement.Features.Projects/Models/MaterialLocalCopy.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace PaintingProjectsManagement.Features.Projects;
+
+/// <summary>
+/// Local read model representing a material as received from integration events.
+/// </summary>
+public class MaterialLocalCopy
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = default!;
+    public double PricePerUnit { get; set; }
+    public string Unit { get; set; } = default!;
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/back/PaintingProjectsManagment.Database/DatabaseContext.cs
+++ b/back/PaintingProjectsManagment.Database/DatabaseContext.cs
@@ -23,6 +23,7 @@ public class DatabaseContext : DbContext
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(DatabaseContext).Assembly);
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(UserConfig).Assembly);
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(SeedHistory).Assembly);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(OutboxDomainMessageConfig).Assembly);
 
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(MaterialConfig).Assembly);
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(PaintColorConfig).Assembly);

--- a/back/PaintingProjectsManagment.Database/Migrations/20250813065952_Initial.Designer.cs
+++ b/back/PaintingProjectsManagment.Database/Migrations/20250813065952_Initial.Designer.cs
@@ -528,7 +528,119 @@ namespace PaintingProjectsManagment.Database.Migrations
 
                     b.HasIndex("TenantId", "Name", "Version");
 
-                    b.ToTable("OutboxMessages", (string)null);
+                    b.ToTable("OutboxDomainMessages", (string)null);
+                });
+
+            modelBuilder.Entity("rbkApiModules.Commons.Core.OutboxIntegrationEvent", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("TEXT");
+
+                    b.Property<int>("Attempts")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<string>("CausationId")
+                        .HasMaxLength(100)
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("CorrelationId")
+                        .HasMaxLength(100)
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime>("OccurredUtc")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Payload")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime?>("ProcessedUtc")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("TenantId")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("TEXT");
+
+                    b.Property<int>("Version")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<string>("Username")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CreatedUtc");
+
+                    b.HasIndex("ProcessedUtc");
+
+                    b.HasIndex("TenantId", "Name", "Version");
+
+                    b.ToTable("OutboxIntegrationEvents", (string)null);
+                });
+
+            modelBuilder.Entity("rbkApiModules.Commons.Core.IntegrationDelivery", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT");
+
+                    b.Property<int>("Attempts")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<Guid>("EventId")
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime?>("ProcessedUtc")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Subscriber")
+                        .IsRequired()
+                        .HasMaxLength(512)
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EventId");
+
+                    b.HasIndex("ProcessedUtc");
+
+                    b.ToTable("IntegrationDeliveries", (string)null);
+                });
+
+            modelBuilder.Entity("PaintingProjectsManagement.Features.Projects.MaterialLocalCopy", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("TEXT");
+
+                    b.Property<double>("PricePerUnit")
+                        .HasColumnType("REAL");
+
+                    b.Property<string>("Unit")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime>("UpdatedUtc")
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("projects.materials_local_copy", (string)null);
                 });
 
             modelBuilder.Entity("rbkApiModules.Commons.Relational.SeedHistory", b =>

--- a/back/PaintingProjectsManagment.Database/Migrations/DatabaseContextModelSnapshot.cs
+++ b/back/PaintingProjectsManagment.Database/Migrations/DatabaseContextModelSnapshot.cs
@@ -525,7 +525,119 @@ namespace PaintingProjectsManagment.Database.Migrations
 
                     b.HasIndex("TenantId", "Name", "Version");
 
-                    b.ToTable("OutboxMessages", (string)null);
+                    b.ToTable("OutboxDomainMessages", (string)null);
+                });
+
+            modelBuilder.Entity("rbkApiModules.Commons.Core.OutboxIntegrationEvent", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("TEXT");
+
+                    b.Property<int>("Attempts")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<string>("CausationId")
+                        .HasMaxLength(100)
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("CorrelationId")
+                        .HasMaxLength(100)
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime>("OccurredUtc")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Payload")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime?>("ProcessedUtc")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("TenantId")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("TEXT");
+
+                    b.Property<int>("Version")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<string>("Username")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CreatedUtc");
+
+                    b.HasIndex("ProcessedUtc");
+
+                    b.HasIndex("TenantId", "Name", "Version");
+
+                    b.ToTable("OutboxIntegrationEvents", (string)null);
+                });
+
+            modelBuilder.Entity("rbkApiModules.Commons.Core.IntegrationDelivery", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT");
+
+                    b.Property<int>("Attempts")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<Guid>("EventId")
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime?>("ProcessedUtc")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Subscriber")
+                        .IsRequired()
+                        .HasMaxLength(512)
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EventId");
+
+                    b.HasIndex("ProcessedUtc");
+
+                    b.ToTable("IntegrationDeliveries", (string)null);
+                });
+
+            modelBuilder.Entity("PaintingProjectsManagement.Features.Projects.MaterialLocalCopy", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("TEXT");
+
+                    b.Property<double>("PricePerUnit")
+                        .HasColumnType("REAL");
+
+                    b.Property<string>("Unit")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime>("UpdatedUtc")
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("projects.materials_local_copy", (string)null);
                 });
 
             modelBuilder.Entity("rbkApiModules.Commons.Relational.SeedHistory", b =>

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Diagnostics/OutboxHealthEndpoints.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Diagnostics/OutboxHealthEndpoints.cs
@@ -18,7 +18,7 @@ namespace PaintingProjectsManagement.Api.Diagnostics
             {
                 var now = DateTime.UtcNow;
 
-                var query = db.Set<OutboxMessage>()
+                var query = db.Set<OutboxDomainMessage>()
                     .Where(x => x.ProcessedUtc == null && (x.DoNotProcessBeforeUtc == null || x.DoNotProcessBeforeUtc <= now));
 
                 var count = await query.CountAsync(ct);

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Integration/IIntegrationEventHandler.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Integration/IIntegrationEventHandler.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// Contract for consumers of integration events.
+/// </summary>
+public interface IIntegrationEventHandler<in TIntegrationEvent>
+{
+    Task Handle(EventEnvelope<TIntegrationEvent> envelope, CancellationToken ct);
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Integration/IntegrationSubscriberRegistry.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Integration/IntegrationSubscriberRegistry.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// Simple registry that maps integration events to their subscriber handler
+/// names. It scans loaded assemblies for implementations of
+/// <see cref="IIntegrationEventHandler{TIntegrationEvent}"/>.
+/// </summary>
+public interface IIntegrationSubscriberRegistry
+{
+    IEnumerable<string> GetSubscribers(string eventName, int version);
+}
+
+public class IntegrationSubscriberRegistry : IIntegrationSubscriberRegistry
+{
+    private readonly Dictionary<(string, int), List<string>> _map = new();
+
+    public IntegrationSubscriberRegistry(IServiceProvider serviceProvider)
+    {
+        var handlerTypes = AppDomain.CurrentDomain
+            .GetAssemblies()
+            .SelectMany(a => a.GetTypes())
+            .Where(t => !t.IsAbstract && !t.IsInterface)
+            .Select(t => new
+            {
+                Handler = t,
+                Interface = t.GetInterfaces()
+                    .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IIntegrationEventHandler<>))
+            })
+            .Where(x => x.Interface != null);
+
+        foreach (var item in handlerTypes)
+        {
+            var eventType = item.Interface!.GenericTypeArguments[0];
+            var attr = eventType.GetCustomAttribute<EventNameAttribute>();
+            if (attr == null)
+            {
+                continue;
+            }
+
+            var key = (attr.Name, attr.Version);
+            if (!_map.TryGetValue(key, out var list))
+            {
+                list = new List<string>();
+                _map[key] = list;
+            }
+
+            list.Add(item.Handler.FullName!);
+        }
+    }
+
+    public IEnumerable<string> GetSubscribers(string eventName, int version)
+    {
+        return _map.TryGetValue((eventName, version), out var list) ? list : Enumerable.Empty<string>();
+    }
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IIntegrationDeliveryScheduler.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IIntegrationDeliveryScheduler.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// Responsible for creating delivery records for the current subscribers of a
+/// given integration event.
+/// </summary>
+public interface IIntegrationDeliveryScheduler
+{
+    Task SeedDeliveriesAsync(Guid eventId, string eventName, int version, CancellationToken ct);
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IIntegrationOutbox.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IIntegrationOutbox.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// Service responsible for storing integration events in the outbox.
+/// </summary>
+public interface IIntegrationOutbox
+{
+    Guid Enqueue<T>(EventEnvelope<T> envelope);
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IntegrationDelivery.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IntegrationDelivery.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// Represents the delivery status of an integration event for a specific
+/// subscriber.
+/// </summary>
+public class IntegrationDelivery
+{
+    public Guid Id { get; set; }
+    public Guid EventId { get; set; }
+    public string Subscriber { get; set; } = default!;
+    public DateTime? ProcessedUtc { get; set; }
+    public int Attempts { get; set; }
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IntegrationDeliveryScheduler.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IntegrationDeliveryScheduler.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// Default implementation that creates delivery records for all subscribers of
+/// a given integration event.
+/// </summary>
+public class IntegrationDeliveryScheduler : IIntegrationDeliveryScheduler
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IIntegrationSubscriberRegistry _registry;
+    private readonly OutboxOptions _options;
+
+    public IntegrationDeliveryScheduler(IServiceScopeFactory scopeFactory,
+        IIntegrationSubscriberRegistry registry,
+        IOptions<OutboxOptions> options)
+    {
+        _scopeFactory = scopeFactory;
+        _registry = registry;
+        _options = options.Value;
+    }
+
+    public async Task SeedDeliveriesAsync(Guid eventId, string eventName, int version, CancellationToken ct)
+    {
+        var subscribers = _registry.GetSubscribers(eventName, version);
+        using var scope = _scopeFactory.CreateScope();
+        var db = _options.ResolveDbContext!(scope.ServiceProvider);
+
+        foreach (var subscriber in subscribers)
+        {
+            db.Set<IntegrationDelivery>().Add(new IntegrationDelivery
+            {
+                Id = Guid.NewGuid(),
+                EventId = eventId,
+                Subscriber = subscriber,
+                Attempts = 0,
+                ProcessedUtc = null
+            });
+        }
+
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IntegrationDispatcher.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IntegrationDispatcher.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// Background service responsible for processing integration deliveries.
+/// </summary>
+public sealed class IntegrationDispatcher : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IEventTypeRegistry _eventRegistry;
+    private readonly ILogger<IntegrationDispatcher> _logger;
+    private readonly OutboxOptions _options;
+
+    public IntegrationDispatcher(IServiceScopeFactory scopeFactory,
+        IEventTypeRegistry eventRegistry,
+        ILogger<IntegrationDispatcher> logger,
+        IOptions<OutboxOptions> options)
+    {
+        _scopeFactory = scopeFactory;
+        _eventRegistry = eventRegistry;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            Guid[] deliveries;
+            using (var scope = _scopeFactory.CreateScope())
+            {
+                var db = _options.ResolveDbContext!(scope.ServiceProvider);
+                deliveries = await db.Set<IntegrationDelivery>()
+                    .AsNoTracking()
+                    .Where(x => x.ProcessedUtc == null && x.Attempts < _options.MaxAttempts)
+                    .OrderBy(x => x.Id)
+                    .Select(x => x.Id)
+                    .Take(_options.BatchSize)
+                    .ToArrayAsync(stoppingToken);
+            }
+
+            foreach (var deliveryId in deliveries)
+            {
+                using var scope = _scopeFactory.CreateScope();
+                var db = _options.ResolveDbContext!(scope.ServiceProvider);
+                var delivery = await db.Set<IntegrationDelivery>().FirstOrDefaultAsync(x => x.Id == deliveryId, stoppingToken);
+                if (delivery == null || delivery.ProcessedUtc != null)
+                {
+                    continue;
+                }
+
+                var evt = await db.Set<OutboxIntegrationEvent>().FirstOrDefaultAsync(x => x.Id == delivery.EventId, stoppingToken);
+                if (evt == null)
+                {
+                    delivery.ProcessedUtc = DateTime.UtcNow;
+                    await db.SaveChangesAsync(stoppingToken);
+                    continue;
+                }
+
+                var eventType = _eventRegistry.GetEventType(evt.Name, evt.Version);
+                if (eventType == null)
+                {
+                    delivery.ProcessedUtc = DateTime.UtcNow;
+                    await db.SaveChangesAsync(stoppingToken);
+                    continue;
+                }
+
+                var envelope = JsonEventSerializer.Deserialize(evt.Payload, eventType);
+                var handlerType = Type.GetType(delivery.Subscriber);
+                if (handlerType == null)
+                {
+                    delivery.ProcessedUtc = DateTime.UtcNow;
+                    await db.SaveChangesAsync(stoppingToken);
+                    continue;
+                }
+
+                try
+                {
+                    var handler = scope.ServiceProvider.GetService(handlerType);
+                    if (handler != null)
+                    {
+                        var method = handlerType.GetMethod("Handle");
+                        var task = (Task?)method?.Invoke(handler, new[] { envelope, stoppingToken });
+                        if (task != null)
+                        {
+                            await task.ConfigureAwait(false);
+                        }
+                    }
+
+                    delivery.ProcessedUtc = DateTime.UtcNow;
+                    await db.SaveChangesAsync(stoppingToken);
+
+                    var remaining = await db.Set<IntegrationDelivery>()
+                        .AnyAsync(x => x.EventId == delivery.EventId && x.ProcessedUtc == null, stoppingToken);
+                    if (!remaining)
+                    {
+                        evt.ProcessedUtc = DateTime.UtcNow;
+                        await db.SaveChangesAsync(stoppingToken);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Integration delivery failed");
+                    delivery.Attempts++;
+                    await db.SaveChangesAsync(stoppingToken);
+                }
+            }
+
+            await Task.Delay(_options.PollIntervalMs, stoppingToken);
+        }
+    }
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IntegrationOutbox.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IntegrationOutbox.cs
@@ -1,0 +1,47 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// Default implementation of <see cref="IIntegrationOutbox"/> using EF Core.
+/// </summary>
+public class IntegrationOutbox : IIntegrationOutbox
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly OutboxOptions _options;
+
+    public IntegrationOutbox(IServiceScopeFactory scopeFactory, IOptions<OutboxOptions> options)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options.Value;
+    }
+
+    public Guid Enqueue<T>(EventEnvelope<T> envelope)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = _options.ResolveDbContext!(scope.ServiceProvider);
+
+        var entity = new OutboxIntegrationEvent
+        {
+            Id = envelope.EventId,
+            Name = envelope.Name,
+            Version = envelope.Version,
+            TenantId = envelope.TenantId,
+            Username = envelope.Username,
+            OccurredUtc = envelope.OccurredUtc,
+            CorrelationId = envelope.CorrelationId,
+            CausationId = envelope.CausationId,
+            Payload = JsonEventSerializer.Serialize(envelope),
+            CreatedUtc = DateTime.UtcNow,
+            ProcessedUtc = null,
+            Attempts = 0
+        };
+
+        db.Set<OutboxIntegrationEvent>().Add(entity);
+        db.SaveChanges();
+
+        return entity.Id;
+    }
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/OutboxDispatcher.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/OutboxDispatcher.cs
@@ -47,7 +47,7 @@ public sealed class OutboxDispatcher : BackgroundService
                     var context = _options.ResolveDbContext!(scope.ServiceProvider);
                     var now = DateTime.UtcNow;
 
-                    batch = await context.Set<OutboxMessage>()
+                    batch = await context.Set<OutboxDomainMessage>()
                         .AsNoTracking()
                         .Where(x => x.ProcessedUtc == null
                                  && (x.DoNotProcessBeforeUtc == null || x.DoNotProcessBeforeUtc <= now)
@@ -65,7 +65,7 @@ public sealed class OutboxDispatcher : BackgroundService
                     var context = _options.ResolveDbContext!(scope.ServiceProvider);
 
                     // (re)load the message in this context
-                    var message = await context.Set<OutboxMessage>().FirstOrDefaultAsync(x => x.Id == messageId, cancellationToken);
+                    var message = await context.Set<OutboxDomainMessage>().FirstOrDefaultAsync(x => x.Id == messageId, cancellationToken);
 
                     if (message is null)
                     {

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/OutboxDomainMessage.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/OutboxDomainMessage.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// Represents an event that originated from the domain and should be
+/// dispatched by the outbox dispatcher. These messages are persisted in the
+/// <c>OutboxDomainMessages</c> table and are processed independently from
+/// integration events.
+/// </summary>
+public class OutboxDomainMessage
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = default!;
+    public int Version { get; set; }
+    public string TenantId { get; set; } = default!;
+    public DateTime OccurredUtc { get; set; }
+    public string? CorrelationId { get; set; }
+    public string? CausationId { get; set; }
+    public string Payload { get; set; } = default!;
+    public DateTime CreatedUtc { get; set; }
+    public DateTime? ProcessedUtc { get; set; }
+    public int Attempts { get; set; }
+    public string Username { get; set; } = default!;
+    public DateTime? DoNotProcessBeforeUtc { get; set; }
+} 

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/OutboxIntegrationEvent.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/OutboxIntegrationEvent.cs
@@ -2,7 +2,11 @@ using System;
 
 namespace rbkApiModules.Commons.Core;
 
-public class OutboxMessage
+/// <summary>
+/// Represents an event that is published to external subscribers via the
+/// integration outbox.
+/// </summary>
+public class OutboxIntegrationEvent
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = default!;
@@ -16,5 +20,4 @@ public class OutboxMessage
     public DateTime? ProcessedUtc { get; set; }
     public int Attempts { get; set; }
     public string Username { get; set; } = default!;
-    public DateTime? DoNotProcessBeforeUtc { get; set; }
-} 
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/Configurations/IntegrationDeliveryConfig.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/Configurations/IntegrationDeliveryConfig.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// EF configuration for <see cref="IntegrationDelivery"/>.
+/// </summary>
+public class IntegrationDeliveryConfig : IEntityTypeConfiguration<IntegrationDelivery>
+{
+    public void Configure(EntityTypeBuilder<IntegrationDelivery> builder)
+    {
+        builder.ToTable("IntegrationDeliveries");
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Subscriber).IsRequired().HasMaxLength(512);
+        builder.Property(x => x.Attempts).IsRequired();
+        builder.Property(x => x.ProcessedUtc);
+
+        builder.HasIndex(x => x.EventId);
+        builder.HasIndex(x => x.ProcessedUtc);
+    }
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/Configurations/OutboxDomainMessageConfig.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/Configurations/OutboxDomainMessageConfig.cs
@@ -4,11 +4,11 @@ using rbkApiModules.Commons.Core;
 
 namespace rbkApiModules.Commons.Core;
 
-public class OutboxMessageConfig : IEntityTypeConfiguration<OutboxMessage>
+public class OutboxDomainMessageConfig : IEntityTypeConfiguration<OutboxDomainMessage>
 {
-    public void Configure(EntityTypeBuilder<OutboxMessage> builder)
+    public void Configure(EntityTypeBuilder<OutboxDomainMessage> builder)
     {
-        builder.ToTable("OutboxMessages");
+        builder.ToTable("OutboxDomainMessages");
         builder.HasKey(x => x.Id);
 
         builder.Property(x => x.Name).IsRequired().HasMaxLength(200);

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/Configurations/OutboxIntegrationEventConfig.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/Configurations/OutboxIntegrationEventConfig.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// EF configuration for <see cref="OutboxIntegrationEvent"/>.
+/// </summary>
+public class OutboxIntegrationEventConfig : IEntityTypeConfiguration<OutboxIntegrationEvent>
+{
+    public void Configure(EntityTypeBuilder<OutboxIntegrationEvent> builder)
+    {
+        builder.ToTable("OutboxIntegrationEvents");
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Name).IsRequired().HasMaxLength(200);
+        builder.Property(x => x.Version).IsRequired();
+        builder.Property(x => x.TenantId).IsRequired().HasMaxLength(100);
+        builder.Property(x => x.OccurredUtc).IsRequired();
+        builder.Property(x => x.CorrelationId).HasMaxLength(100);
+        builder.Property(x => x.CausationId).HasMaxLength(100);
+        builder.Property(x => x.Payload).IsRequired();
+        builder.Property(x => x.CreatedUtc).IsRequired();
+        builder.Property(x => x.ProcessedUtc);
+        builder.Property(x => x.Attempts).IsRequired();
+
+        builder.HasIndex(x => new { x.TenantId, x.Name, x.Version });
+        builder.HasIndex(x => x.ProcessedUtc);
+        builder.HasIndex(x => x.CreatedUtc);
+    }
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/Interceptors/OutboxSaveChangesInterceptor.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/Interceptors/OutboxSaveChangesInterceptor.cs
@@ -58,7 +58,7 @@ public sealed class OutboxSaveChangesInterceptor : SaveChangesInterceptor
                 var envelope = EventEnvelopeFactory.Wrap(domainEvent, _requestContext.TenantId, _requestContext.Username, _requestContext.CorrelationId, _requestContext.CausationId);
                 var payload = JsonEventSerializer.Serialize(envelope);
 
-                context.Set<OutboxMessage>().Add(new OutboxMessage
+                context.Set<OutboxDomainMessage>().Add(new OutboxDomainMessage
                 {
                     Id = envelope.EventId,
                     Name = envelope.Name,


### PR DESCRIPTION
## Summary
- introduce separate domain and integration outboxes with per-subscriber deliveries
- wire up integration dispatcher, registry, and scheduling
- sync projects module with materials via integration event consumers

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet test PaintingProjectsManagment.sln` *(fails: NETSDK1045 - current SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689c856aec308328832a110efac42de8