### PR TITLE
feat: add integration outbox and materials sync

### DIFF
--- a/back/PaintingProjectsManagement.Api/Program.cs
+++ b/back/PaintingProjectsManagement.Api/Program.cs
@@ -60,9 +60,15 @@ public class Program
 
         // TODO: move to the library builder with the possibility to disable it with startup options
         builder.Services.AddHostedService<OutboxDispatcher>();
+        builder.Services.AddHostedService<IntegrationDispatcher>();
 
-        // Register domain-to-integration event handlers for Materials
+        builder.Services.AddSingleton<IIntegrationSubscriberRegistry, IntegrationSubscriberRegistry>();
+        builder.Services.AddScoped<IIntegrationOutbox, IntegrationOutbox>();
+        builder.Services.AddScoped<IIntegrationDeliveryScheduler, IntegrationDeliveryScheduler>();
+
+        // Register domain-to-integration event handlers for Materials and integration consumers for Projects
         builder.Services.AddMaterialsIntegrationHandlers();
+        builder.Services.AddProjectsIntegrationHandlers();
 
         builder.Services.AddRbkApiCoreSetup(options => options
              .EnableBasicAuthenticationHandler()

--- a/back/PaintingProjectsManagement.Features.Materials.Abstractions/Integrations/Events/MaterialEvents.cs
+++ b/back/PaintingProjectsManagement.Features.Materials.Abstractions/Integrations/Events/MaterialEvents.cs
@@ -9,13 +9,13 @@ public sealed record MaterialCreatedV1(
     string PackageContentUnit,
     double PackagePriceAmount,
     string PackagePriceCurrency
-) : IDomainEvent;
+ ) : IIntegrationEvent;
 
 // Fired when a material is (soft-)deleted
 [EventName("Materials.Integration.MaterialDeleted.v1", 1)]
 public sealed record MaterialDeletedV1(
     Guid MaterialId
-) : IDomainEvent;
+ ) : IIntegrationEvent;
 
 // Fired when a material changes
 [EventName("Materials.Integration.MaterialUpdated.v1", 1)]
@@ -26,4 +26,4 @@ public sealed record MaterialPackageContentChanged(
     string PackageContentUnit,
     double PackagePriceAmount,
     string PackagePriceCurrency
-) : IDomainEvent;
+ ) : IIntegrationEvent;

--- a/back/PaintingProjectsManagement.Features.Materials.Tests/UseCases/Create_Material_Tests.cs
+++ b/back/PaintingProjectsManagement.Features.Materials.Tests/UseCases/Create_Material_Tests.cs
@@ -15,7 +15,7 @@ public class Create_Material_Tests
         var existingMaterial = new Material(
             "rodrigo.basniak",
             "Existing Material",
-            new Quantity(1, PackageUnit.Each),
+            new Quantity(1, PackageContentUnit.Each),
             new Money(10.0, "USD")
         );
 
@@ -46,8 +46,8 @@ public class Create_Material_Tests
         var request = new CreateMaterial.Request
         {
             Name = "Test Material",
-            PackageAmount = 1,
-            PackageUnit = PackageUnit.Each,
+            PackageContentAmount = 1,
+            PackageContentUnit = PackageContentUnit.Each,
             PackagePriceAmount = 19,
             PackagePriceCurrency = "USD",
         };
@@ -66,14 +66,14 @@ public class Create_Material_Tests
     [Test, NotInParallel(Order = 3)]
     [Arguments(0)]
     [Arguments(-1)]
-    public async Task User_Cannot_Create_Material_When_PackageAmount_Is_Not_Positive(double packageAmount)
+    public async Task User_Cannot_Create_Material_When_PackageContentAmount_Is_Not_Positive(double packageAmount)
     {
         // Prepare
         var request = new CreateMaterial.Request
         {
             Name = "Invalid Amount",
-            PackageAmount = packageAmount,
-            PackageUnit = PackageUnit.Each,
+            PackageContentAmount = packageAmount,
+            PackageContentUnit = PackageContentUnit.Each,
             PackagePriceAmount = 19,
             PackagePriceCurrency = "USD",
         };
@@ -96,8 +96,8 @@ public class Create_Material_Tests
         var request = new CreateMaterial.Request
         {
             Name = "Existing Material", // This name was created in Seed test
-            PackageAmount = 1,
-            PackageUnit = PackageUnit.Each,
+            PackageContentAmount = 1,
+            PackageContentUnit = PackageContentUnit.Each,
             PackagePriceAmount = 15,
             PackagePriceCurrency = "USD",
         };
@@ -120,8 +120,8 @@ public class Create_Material_Tests
         var request = new CreateMaterial.Request
         {
             Name = "Existing Material", // This name was created by rodrigo.basniak in Seed test
-            PackageAmount = 1,
-            PackageUnit = PackageUnit.Each,
+            PackageContentAmount = 1,
+            PackageContentUnit = PackageContentUnit.Each,
             PackagePriceAmount = 25,
             PackagePriceCurrency = "USD",
         };
@@ -137,7 +137,7 @@ public class Create_Material_Tests
         result.PackagePrice.Amount.ShouldBe(25);
         result.PackagePrice.CurrencyCode.ShouldBe("USD");
         result.PackagetContent.Amount.ShouldBe(1);
-        EnumAssertionExtensions.ShouldBeEquivalentTo(result.PackagetContent.Unit, PackageUnit.Each);
+        EnumAssertionExtensions.ShouldBeEquivalentTo(result.PackagetContent.Unit, PackageContentUnit.Each);
 
         // Assert the database - should have two materials with the same name but different users
         var materials = TestingServer.CreateContext().Set<Material>().Where(x => x.Name == "Existing Material").ToList();
@@ -149,11 +149,11 @@ public class Create_Material_Tests
         rbMaterial.ShouldNotBeNull();
         rbMaterial.Id.ShouldNotBe(rsMaterial.Id);
         rbMaterial.UnitPriceAmount.ShouldBe(10.0); // From Seed test
-        rbMaterial.UnitPriceUnit.ShouldBe(PackageUnit.Each); // From Seed test
+        rbMaterial.UnitPriceUnit.ShouldBe(PackageContentUnit.Each); // From Seed test
 
         rsMaterial.ShouldNotBeNull();
         rsMaterial.UnitPriceAmount.ShouldBe(25);
-        rsMaterial.UnitPriceUnit.ShouldBe(PackageUnit.Each);
+        rsMaterial.UnitPriceUnit.ShouldBe(PackageContentUnit.Each);
     }
 
     [Test, NotInParallel(Order = 14)]
@@ -163,8 +163,8 @@ public class Create_Material_Tests
         var request = new CreateMaterial.Request
         {
             Name = "8x4 magnet for test",
-            PackageAmount = 1,
-            PackageUnit = PackageUnit.Each,
+            PackageContentAmount = 1,
+            PackageContentUnit = PackageContentUnit.Each,
             PackagePriceAmount = 19,
             PackagePriceCurrency = "USD",
         };
@@ -186,7 +186,7 @@ public class Create_Material_Tests
         entity.Id.ShouldBe(result.Id);
         entity.Name.ShouldBe("8x4 magnet for test");
         entity.UnitPriceAmount.ShouldBe(19);
-        entity.UnitPriceUnit.ShouldBe(PackageUnit.Each);
+        entity.UnitPriceUnit.ShouldBe(PackageContentUnit.Each);
     }
 
     [Test, NotInParallel(Order = 99)]

--- a/back/PaintingProjectsManagement.Features.Materials.Tests/UseCases/Update_Material_Tests.cs
+++ b/back/PaintingProjectsManagement.Features.Materials.Tests/UseCases/Update_Material_Tests.cs
@@ -11,9 +11,9 @@ public class Update_Material_Tests
     public async Task Seed()
     {
         // Create test materials for different users
-        var existingMaterial = new Material("rodrigo.basniak", "Existing Material", new Quantity(1, PackageUnit.Each), new Money(10.0, "USD"));
-        var anotherUserMaterial = new Material("ricardo.smarzaro", "Another User Material", new Quantity(1, PackageUnit.Each), new Money(5.0, "USD"));
-        var duplicateNameMaterial = new Material("rodrigo.basniak", "Duplicate Name Material", new Quantity(1, PackageUnit.Each), new Money(15.0, "USD"));
+        var existingMaterial = new Material("rodrigo.basniak", "Existing Material", new Quantity(1, PackageContentUnit.Each), new Money(10.0, "USD"));
+        var anotherUserMaterial = new Material("ricardo.smarzaro", "Another User Material", new Quantity(1, PackageContentUnit.Each), new Money(5.0, "USD"));
+        var duplicateNameMaterial = new Material("rodrigo.basniak", "Duplicate Name Material", new Quantity(1, PackageContentUnit.Each), new Money(15.0, "USD"));
 
         using (var context = TestingServer.CreateContext())
         {
@@ -54,8 +54,8 @@ public class Update_Material_Tests
         {
             Id = existingMaterial.Id,
             Name = "Updated Material",
-            PackageAmount = 2,
-            PackageUnit = PackageUnit.Each,
+            PackageContentAmount = 2,
+            PackageContentUnit = PackageContentUnit.Each,
             PackagePriceAmount = 25.0,
             PackagePriceCurrency = "USD",
         };
@@ -81,8 +81,8 @@ public class Update_Material_Tests
         {
             Id = nonExistentId,
             Name = "Updated Material",
-            PackageAmount = 2,
-            PackageUnit = PackageUnit.Each,
+            PackageContentAmount = 2,
+            PackageContentUnit = PackageContentUnit.Each,
             PackagePriceAmount = 25.0,
             PackagePriceCurrency = "USD",
         };
@@ -110,8 +110,8 @@ public class Update_Material_Tests
         {
             Id = anotherUserMaterial.Id,
             Name = "Hacked Material",
-            PackageAmount = 2,
-            PackageUnit = PackageUnit.Each,
+            PackageContentAmount = 2,
+            PackageContentUnit = PackageContentUnit.Each,
             PackagePriceAmount = 100.0,
             PackagePriceCurrency = "USD",
         };
@@ -140,8 +140,8 @@ public class Update_Material_Tests
         {
             Id = existingMaterial.Id,
             Name = "Duplicate Name Material", // This name already exists for the same user
-            PackageAmount = 2,
-            PackageUnit = PackageUnit.Each,
+            PackageContentAmount = 2,
+            PackageContentUnit = PackageContentUnit.Each,
             PackagePriceAmount = 25.0,
             PackagePriceCurrency = "USD",
         };
@@ -169,8 +169,8 @@ public class Update_Material_Tests
         {
             Id = duplicateNameMaterial.Id,
             Name = "Another User Material", // This name exists for another user (ricardo.smarzaro)
-            PackageAmount = 2,
-            PackageUnit = PackageUnit.Each,
+            PackageContentAmount = 2,
+            PackageContentUnit = PackageContentUnit.Each,
             PackagePriceAmount = 30.0,
             PackagePriceCurrency = "USD",
         };
@@ -186,7 +186,7 @@ public class Update_Material_Tests
         updatedEntity.ShouldNotBeNull();
         updatedEntity.Name.ShouldBe("Another User Material");
         updatedEntity.UnitPriceAmount.ShouldBe(15.0); // 30/2 = 15
-        updatedEntity.UnitPriceUnit.ShouldBe(PackageUnit.Each);
+        updatedEntity.UnitPriceUnit.ShouldBe(PackageContentUnit.Each);
         updatedEntity.TenantId.ShouldBe("RODRIGO.BASNIAK"); // Should still belong to the original user
 
         // Verify the other user's material is unchanged
@@ -205,8 +205,8 @@ public class Update_Material_Tests
         {
             Id = existingMaterial.Id,
             Name = "Existing Material", // Same name as itself
-            PackageAmount = 2,
-            PackageUnit = PackageUnit.Each,
+            PackageContentAmount = 2,
+            PackageContentUnit = PackageContentUnit.Each,
             PackagePriceAmount = 50.0, // Change price
             PackagePriceCurrency = "USD",
         };
@@ -222,7 +222,7 @@ public class Update_Material_Tests
         updatedEntity.ShouldNotBeNull();
         updatedEntity.Name.ShouldBe("Existing Material"); // Name remains the same
         updatedEntity.UnitPriceAmount.ShouldBe(25.0); // 50/2 = 25
-        updatedEntity.UnitPriceUnit.ShouldBe(PackageUnit.Each); // Unit was updated
+        updatedEntity.UnitPriceUnit.ShouldBe(PackageContentUnit.Each); // Unit was updated
     }
 
     [Test, NotInParallel(Order = 12)]
@@ -236,8 +236,8 @@ public class Update_Material_Tests
         {
             Id = existingMaterial.Id,
             Name = "Updated Material Name",
-            PackageAmount = 2,
-            PackageUnit = PackageUnit.Each,
+            PackageContentAmount = 2,
+            PackageContentUnit = PackageContentUnit.Each,
             PackagePriceAmount = 25.50,
             PackagePriceCurrency = "USD",
         };
@@ -254,7 +254,7 @@ public class Update_Material_Tests
         updatedEntity.Id.ShouldBe(existingMaterial.Id);
         updatedEntity.Name.ShouldBe("Updated Material Name");
         updatedEntity.UnitPriceAmount.ShouldBe(12.75); // 25.5/2
-        updatedEntity.UnitPriceUnit.ShouldBe(PackageUnit.Each);
+        updatedEntity.UnitPriceUnit.ShouldBe(PackageContentUnit.Each);
         updatedEntity.TenantId.ShouldBe("RODRIGO.BASNIAK"); // Should still belong to the same user
     }
 

--- a/back/PaintingProjectsManagement.Features.Materials/Integrations/Handlers/MaterialCreatedHandler.cs
+++ b/back/PaintingProjectsManagement.Features.Materials/Integrations/Handlers/MaterialCreatedHandler.cs
@@ -1,19 +1,17 @@
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using PaintingProjectsManagement.Features.Materials.Abstractions;
 using rbkApiModules.Commons.Core;
 
 namespace PaintingProjectsManagement.Features.Materials;
 
-public sealed class MaterialCreatedHandler : IEventHandler<MaterialCreated>
+internal sealed class MaterialCreatedHandler : IEventHandler<MaterialCreated>
 {
-    private readonly IServiceScopeFactory _scopeFactory;
-    private readonly IOptions<OutboxOptions> _outboxOptions;
+    private readonly IIntegrationOutbox _outbox;
+    private readonly IIntegrationDeliveryScheduler _scheduler;
 
-    public MaterialCreatedHandler(IServiceScopeFactory scopeFactory, IOptions<OutboxOptions> outboxOptions)
+    public MaterialCreatedHandler(IIntegrationOutbox outbox, IIntegrationDeliveryScheduler scheduler)
     {
-        _scopeFactory = scopeFactory;
-        _outboxOptions = outboxOptions;
+        _outbox = outbox;
+        _scheduler = scheduler;
     }
 
     public async Task Handle(EventEnvelope<MaterialCreated> envelope, CancellationToken cancellationToken)
@@ -37,28 +35,8 @@ public sealed class MaterialCreatedHandler : IEventHandler<MaterialCreated>
             envelope.EventId.ToString()
         );
 
-        var payload = JsonEventSerializer.Serialize(integrationEnvelope);
-
-        using var scope = _scopeFactory.CreateScope();
-        var dbContext = _outboxOptions.Value.ResolveDbContext!(scope.ServiceProvider);
-
-        dbContext.Set<OutboxMessage>().Add(new OutboxMessage
-        {
-            Id = integrationEnvelope.EventId,
-            Name = integrationEnvelope.Name,
-            Version = integrationEnvelope.Version,
-            TenantId = integrationEnvelope.TenantId,
-            Username = integrationEnvelope.Username,
-            OccurredUtc = integrationEnvelope.OccurredUtc,
-            CorrelationId = integrationEnvelope.CorrelationId,
-            CausationId = integrationEnvelope.CausationId,
-            Payload = payload,
-            CreatedUtc = DateTime.UtcNow,
-            ProcessedUtc = null,
-            Attempts = 0
-        });
-
-        await dbContext.SaveChangesAsync(cancellationToken);
+        var id = await _outbox.Enqueue(integrationEnvelope, cancellationToken);
+        await _scheduler.SeedDeliveriesAsync(id, integrationEnvelope.Name, integrationEnvelope.Version, cancellationToken);
     }
 }
 

--- a/back/PaintingProjectsManagement.Features.Projects/Database/MaterialCopyConfig.cs
+++ b/back/PaintingProjectsManagement.Features.Projects/Database/MaterialCopyConfig.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace PaintingProjectsManagement.Features.Projects;
+
+public class MaterialCopyConfig : IEntityTypeConfiguration<MaterialCopy>
+{
+    public void Configure(EntityTypeBuilder<MaterialCopy> builder)
+    {
+        builder.ToTable("MaterialCopies");
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Name).IsRequired().HasMaxLength(200);
+        builder.Property(x => x.PricePerUnit).IsRequired();
+        builder.Property(x => x.Unit).IsRequired().HasMaxLength(50);
+        builder.Property(x => x.UpdatedUtc).IsRequired();
+    }
+}

--- a/back/PaintingProjectsManagement.Features.Projects/Integrations/Handlers/MaterialCreatedConsumer.cs
+++ b/back/PaintingProjectsManagement.Features.Projects/Integrations/Handlers/MaterialCreatedConsumer.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using PaintingProjectsManagement.Features.Materials.Abstractions;
+using rbkApiModules.Commons.Core;
+
+namespace PaintingProjectsManagement.Features.Projects;
+
+public class MaterialCreatedConsumer : IIntegrationEventHandler<MaterialCreatedV1>
+{
+    private readonly DbContext _db;
+
+    public MaterialCreatedConsumer(DbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task Handle(EventEnvelope<MaterialCreatedV1> envelope, CancellationToken cancellationToken)
+    {
+        var e = envelope.Event;
+        var pricePerUnit = e.PackageContentAmount == 0 ? 0 : e.PackagePriceAmount / e.PackageContentAmount;
+        var entity = await _db.Set<MaterialCopy>().FindAsync(new object[] { e.MaterialId }, cancellationToken);
+        if (entity == null)
+        {
+            entity = new MaterialCopy { Id = e.MaterialId };
+            _db.Add(entity);
+        }
+        entity.Name = e.Name;
+        entity.PricePerUnit = pricePerUnit;
+        entity.Unit = e.PackageContentUnit;
+        entity.UpdatedUtc = DateTime.UtcNow;
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/back/PaintingProjectsManagement.Features.Projects/Integrations/Handlers/MaterialDeletedConsumer.cs
+++ b/back/PaintingProjectsManagement.Features.Projects/Integrations/Handlers/MaterialDeletedConsumer.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using PaintingProjectsManagement.Features.Materials.Abstractions;
+using rbkApiModules.Commons.Core;
+
+namespace PaintingProjectsManagement.Features.Projects;
+
+public class MaterialDeletedConsumer : IIntegrationEventHandler<MaterialDeletedV1>
+{
+    private readonly DbContext _db;
+
+    public MaterialDeletedConsumer(DbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task Handle(EventEnvelope<MaterialDeletedV1> envelope, CancellationToken cancellationToken)
+    {
+        var entity = await _db.Set<MaterialCopy>().FindAsync(new object[] { envelope.Event.MaterialId }, cancellationToken);
+        if (entity != null)
+        {
+            _db.Remove(entity);
+            await _db.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/back/PaintingProjectsManagement.Features.Projects/Integrations/Handlers/MaterialUpdatedConsumer.cs
+++ b/back/PaintingProjectsManagement.Features.Projects/Integrations/Handlers/MaterialUpdatedConsumer.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using PaintingProjectsManagement.Features.Materials.Abstractions;
+using rbkApiModules.Commons.Core;
+
+namespace PaintingProjectsManagement.Features.Projects;
+
+public class MaterialUpdatedConsumer : IIntegrationEventHandler<MaterialPackageContentChanged>
+{
+    private readonly DbContext _db;
+
+    public MaterialUpdatedConsumer(DbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task Handle(EventEnvelope<MaterialPackageContentChanged> envelope, CancellationToken cancellationToken)
+    {
+        var e = envelope.Event;
+        var pricePerUnit = e.PackageContentAmount == 0 ? 0 : e.PackagePriceAmount / e.PackageContentAmount;
+        var entity = await _db.Set<MaterialCopy>().FindAsync(new object[] { e.MaterialId }, cancellationToken);
+        if (entity == null)
+        {
+            entity = new MaterialCopy { Id = e.MaterialId };
+            _db.Add(entity);
+        }
+        entity.Name = e.Name;
+        entity.PricePerUnit = pricePerUnit;
+        entity.Unit = e.PackageContentUnit;
+        entity.UpdatedUtc = DateTime.UtcNow;
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/back/PaintingProjectsManagement.Features.Projects/Integrations/ProjectsIntegrationBuilder.cs
+++ b/back/PaintingProjectsManagement.Features.Projects/Integrations/ProjectsIntegrationBuilder.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.DependencyInjection;
+using PaintingProjectsManagement.Features.Materials.Abstractions;
+using rbkApiModules.Commons.Core;
+
+namespace PaintingProjectsManagement.Features.Projects;
+
+public static class ProjectsIntegrationBuilder
+{
+    public static IServiceCollection AddProjectsIntegrationHandlers(this IServiceCollection services)
+    {
+        services.AddScoped<IIntegrationEventHandler<MaterialCreatedV1>, MaterialCreatedConsumer>();
+        services.AddScoped<IIntegrationEventHandler<MaterialPackageContentChanged>, MaterialUpdatedConsumer>();
+        services.AddScoped<IIntegrationEventHandler<MaterialDeletedV1>, MaterialDeletedConsumer>();
+        return services;
+    }
+}

--- a/back/PaintingProjectsManagement.Features.Projects/Models/MaterialCopy.cs
+++ b/back/PaintingProjectsManagement.Features.Projects/Models/MaterialCopy.cs
@@ -1,0 +1,10 @@
+namespace PaintingProjectsManagement.Features.Projects;
+
+public class MaterialCopy
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = default!;
+    public double PricePerUnit { get; set; }
+    public string Unit { get; set; } = default!;
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/back/PaintingProjectsManagement.Features.Projects/PaintingProjectsManagement.Features.Projects.csproj
+++ b/back/PaintingProjectsManagement.Features.Projects/PaintingProjectsManagement.Features.Projects.csproj
@@ -9,9 +9,9 @@
 	<ItemGroup>
 		<ProjectReference Include="..\PaintingProjectsManagement.Features.Materials.Abstractions\PaintingProjectsManagement.Features.Materials.Abstractions.csproj" />
 		<ProjectReference Include="..\PaintingProjectsManagement.Features.Projects.Abstractions\PaintingProjectsManagement.Features.Projects.Abstractions.csproj" />
-		<ProjectReference Include="..\rbkApiModules\rbkApiModules.Commons.Core\rbkApiModules.Commons.Core.csproj" />
-		<ProjectReference Include="..\PaintingProjectsManagement.FeatureDependencies\PaintingProjectsManagement.FeatureDependencies.csproj" />
-	</ItemGroup>
+                <ProjectReference Include="..\rbkApiModules\rbkApiModules.Commons.Core\rbkApiModules.Commons.Core.csproj" />
+                <ProjectReference Include="..\PaintingProjectsManagement.FeatureDependencies\PaintingProjectsManagement.FeatureDependencies.csproj" />
+        </ItemGroup>
 
 
 	<ItemGroup>

--- a/back/PaintingProjectsManagment.Database/DatabaseContext.cs
+++ b/back/PaintingProjectsManagment.Database/DatabaseContext.cs
@@ -6,6 +6,7 @@ using PaintingProjectsManagement.Features.Projects;
 using rbkApiModules.Authentication;
 using rbkApiModules.Commons.Relational;
 using rbkApiModules.Identity;
+using rbkApiModules.Commons.Core;
 
 namespace PaintingProjectsManagment.Database;
 
@@ -28,6 +29,7 @@ public class DatabaseContext : DbContext
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(PaintColorConfig).Assembly);
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(ModelConfig).Assembly);
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(ProjectConfig).Assembly);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(OutboxDomainMessageConfig).Assembly);
 
         modelBuilder.Entity<MaterialForProject>()
             .HasOne<Material>()

--- a/back/PaintingProjectsManagment.Database/Migrations/20250813070000_SplitOutboxes.cs
+++ b/back/PaintingProjectsManagment.Database/Migrations/20250813070000_SplitOutboxes.cs
@@ -1,0 +1,117 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PaintingProjectsManagment.Database.Migrations
+{
+    public partial class SplitOutboxes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameTable(
+                name: "OutboxMessages",
+                newName: "OutboxDomainMessages");
+
+            migrationBuilder.CreateTable(
+                name: "OutboxIntegrationEvents",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
+                    Version = table.Column<int>(type: "INTEGER", nullable: false),
+                    TenantId = table.Column<string>(type: "TEXT", maxLength: 100, nullable: false),
+                    OccurredUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    CorrelationId = table.Column<string>(type: "TEXT", maxLength: 100, nullable: true),
+                    CausationId = table.Column<string>(type: "TEXT", maxLength: 100, nullable: true),
+                    Payload = table.Column<string>(type: "TEXT", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    ProcessedUtc = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    Attempts = table.Column<int>(type: "INTEGER", nullable: false),
+                    Username = table.Column<string>(type: "TEXT", nullable: false),
+                    DoNotProcessBeforeUtc = table.Column<DateTime>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OutboxIntegrationEvents", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "IntegrationDeliveries",
+                columns: table => new
+                {
+                    EventId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Subscriber = table.Column<string>(type: "TEXT", maxLength: 500, nullable: false),
+                    ProcessedUtc = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    Attempts = table.Column<int>(type: "INTEGER", nullable: false),
+                    DoNotProcessBeforeUtc = table.Column<DateTime>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_IntegrationDeliveries", x => new { x.EventId, x.Subscriber });
+                    table.ForeignKey(
+                        name: "FK_IntegrationDeliveries_OutboxIntegrationEvents_EventId",
+                        column: x => x.EventId,
+                        principalTable: "OutboxIntegrationEvents",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxIntegrationEvents_TenantId_Name_Version",
+                table: "OutboxIntegrationEvents",
+                columns: new[] { "TenantId", "Name", "Version" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxIntegrationEvents_ProcessedUtc",
+                table: "OutboxIntegrationEvents",
+                column: "ProcessedUtc");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxIntegrationEvents_CreatedUtc",
+                table: "OutboxIntegrationEvents",
+                column: "CreatedUtc");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxIntegrationEvents_DoNotProcessBeforeUtc",
+                table: "OutboxIntegrationEvents",
+                column: "DoNotProcessBeforeUtc");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IntegrationDeliveries_ProcessedUtc",
+                table: "IntegrationDeliveries",
+                column: "ProcessedUtc");
+
+            migrationBuilder.CreateTable(
+                name: "MaterialCopies",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
+                    PricePerUnit = table.Column<double>(type: "REAL", nullable: false),
+                    Unit = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false),
+                    UpdatedUtc = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MaterialCopies", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "IntegrationDeliveries");
+
+            migrationBuilder.DropTable(
+                name: "OutboxIntegrationEvents");
+
+            migrationBuilder.DropTable(
+                name: "MaterialCopies");
+
+            migrationBuilder.RenameTable(
+                name: "OutboxDomainMessages",
+                newName: "OutboxMessages");
+        }
+    }
+}

--- a/back/PaintingProjectsManagment.Database/Migrations/DatabaseContextModelSnapshot.cs
+++ b/back/PaintingProjectsManagment.Database/Migrations/DatabaseContextModelSnapshot.cs
@@ -465,7 +465,7 @@ namespace PaintingProjectsManagment.Database.Migrations
                     b.ToTable("InboxMessages", (string)null);
                 });
 
-            modelBuilder.Entity("rbkApiModules.Commons.Core.OutboxMessage", b =>
+            modelBuilder.Entity("rbkApiModules.Commons.Core.OutboxDomainMessage", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
@@ -525,7 +525,7 @@ namespace PaintingProjectsManagment.Database.Migrations
 
                     b.HasIndex("TenantId", "Name", "Version");
 
-                    b.ToTable("OutboxMessages", (string)null);
+                    b.ToTable("OutboxDomainMessages", (string)null);
                 });
 
             modelBuilder.Entity("rbkApiModules.Commons.Relational.SeedHistory", b =>
@@ -916,7 +916,7 @@ namespace PaintingProjectsManagment.Database.Migrations
                         .OnDelete(DeleteBehavior.Restrict);
                 });
 
-            modelBuilder.Entity("rbkApiModules.Commons.Core.OutboxMessage", b =>
+            modelBuilder.Entity("rbkApiModules.Commons.Core.OutboxDomainMessage", b =>
                 {
                     b.HasOne("rbkApiModules.Identity.Core.Tenant", null)
                         .WithMany()

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Diagnostics/OutboxHealthEndpoints.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Diagnostics/OutboxHealthEndpoints.cs
@@ -18,7 +18,7 @@ namespace PaintingProjectsManagement.Api.Diagnostics
             {
                 var now = DateTime.UtcNow;
 
-                var query = db.Set<OutboxMessage>()
+                var query = db.Set<OutboxDomainMessage>()
                     .Where(x => x.ProcessedUtc == null && (x.DoNotProcessBeforeUtc == null || x.DoNotProcessBeforeUtc <= now));
 
                 var count = await query.CountAsync(ct);

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Events/Handling/IIntegrationEventHandler.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Events/Handling/IIntegrationEventHandler.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// Contract implemented by services that handle integration events dispatched
+/// from the integration outbox.
+/// </summary>
+public interface IIntegrationEventHandler<TIntegrationEvent>
+{
+    Task Handle(EventEnvelope<TIntegrationEvent> envelope, CancellationToken cancellationToken);
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Events/Registry/IIntegrationSubscriberRegistry.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Events/Registry/IIntegrationSubscriberRegistry.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// Provides information about integration event subscribers registered in the
+/// application.
+/// </summary>
+public interface IIntegrationSubscriberRegistry
+{
+    IEnumerable<string> GetSubscribers(string eventName, int version);
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Events/Registry/IntegrationSubscriberRegistry.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Events/Registry/IntegrationSubscriberRegistry.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// Simple reflection based registry for integration event subscribers.
+/// It scans loaded assemblies for implementations of
+/// <see cref="IIntegrationEventHandler{T}"/> and maps them by event name and version.
+/// </summary>
+public sealed class IntegrationSubscriberRegistry : IIntegrationSubscriberRegistry
+{
+    private readonly Dictionary<(string Name, int Version), List<string>> _map = new();
+
+    public IntegrationSubscriberRegistry()
+    {
+        var handlerTypes = AppDomain.CurrentDomain
+            .GetAssemblies()
+            .SelectMany(a => a.GetTypes())
+            .Where(t => !t.IsAbstract && !t.IsInterface)
+            .Select(t => new
+            {
+                Handler = t,
+                Interfaces = t.GetInterfaces()
+                               .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IIntegrationEventHandler<>))
+            })
+            .Where(x => x.Interfaces.Any());
+
+        foreach (var item in handlerTypes)
+        {
+            foreach (var @interface in item.Interfaces)
+            {
+                var eventType = @interface.GetGenericArguments()[0];
+                var attr = eventType.GetCustomAttribute<EventNameAttribute>();
+                if (attr == null)
+                {
+                    continue;
+                }
+                var key = (attr.Name, attr.Version);
+                if (!_map.TryGetValue(key, out var list))
+                {
+                    list = new List<string>();
+                    _map[key] = list;
+                }
+                list.Add(item.Handler.FullName!);
+            }
+        }
+    }
+
+    public IEnumerable<string> GetSubscribers(string eventName, int version)
+        => _map.TryGetValue((eventName, version), out var list) ? list : Enumerable.Empty<string>();
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IIntegrationDeliveryScheduler.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IIntegrationDeliveryScheduler.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace rbkApiModules.Commons.Core;
+
+public interface IIntegrationDeliveryScheduler
+{
+    Task SeedDeliveriesAsync(Guid eventId, string eventName, int version, CancellationToken ct = default);
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IIntegrationOutbox.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IIntegrationOutbox.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace rbkApiModules.Commons.Core;
+
+public interface IIntegrationOutbox
+{
+    Task<Guid> Enqueue<T>(EventEnvelope<T> envelope, CancellationToken ct = default);
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IntegrationDelivery.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IntegrationDelivery.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// Represents the delivery of an integration event to a specific subscriber.
+/// </summary>
+public class IntegrationDelivery
+{
+    public Guid EventId { get; set; }
+    public string Subscriber { get; set; } = default!;
+    public DateTime? ProcessedUtc { get; set; }
+    public int Attempts { get; set; }
+    public DateTime? DoNotProcessBeforeUtc { get; set; }
+
+    public OutboxIntegrationEvent Event { get; set; } = default!;
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IntegrationDeliveryScheduler.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IntegrationDeliveryScheduler.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace rbkApiModules.Commons.Core;
+
+public class IntegrationDeliveryScheduler : IIntegrationDeliveryScheduler
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IIntegrationSubscriberRegistry _registry;
+    private readonly OutboxOptions _options;
+
+    public IntegrationDeliveryScheduler(IServiceScopeFactory scopeFactory,
+        IIntegrationSubscriberRegistry registry,
+        IOptions<OutboxOptions> options)
+    {
+        _scopeFactory = scopeFactory;
+        _registry = registry;
+        _options = options.Value;
+    }
+
+    public async Task SeedDeliveriesAsync(Guid eventId, string eventName, int version, CancellationToken ct = default)
+    {
+        var subscribers = _registry.GetSubscribers(eventName, version);
+        using var scope = _scopeFactory.CreateScope();
+        var db = _options.ResolveDbContext!(scope.ServiceProvider);
+        foreach (var subscriber in subscribers)
+        {
+            db.Set<IntegrationDelivery>().Add(new IntegrationDelivery
+            {
+                EventId = eventId,
+                Subscriber = subscriber,
+                Attempts = 0
+            });
+        }
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IntegrationDispatcher.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IntegrationDispatcher.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// Background service responsible for delivering integration events to
+/// their subscribers using the IntegrationDeliveries table.
+/// </summary>
+public sealed class IntegrationDispatcher : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IEventTypeRegistry _eventTypeRegistry;
+    private readonly ILogger<IntegrationDispatcher> _logger;
+    private readonly OutboxOptions _options;
+
+    public IntegrationDispatcher(
+        IServiceScopeFactory scopeFactory,
+        IEventTypeRegistry eventTypeRegistry,
+        ILogger<IntegrationDispatcher> logger,
+        IOptions<OutboxOptions> options)
+    {
+        _scopeFactory = scopeFactory;
+        _eventTypeRegistry = eventTypeRegistry;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("IntegrationDispatcher started");
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                (Guid EventId, string Subscriber)[] batch = [];
+                using (var scope = _scopeFactory.CreateScope())
+                {
+                    var db = _options.ResolveDbContext!(scope.ServiceProvider);
+                    var now = DateTime.UtcNow;
+                    batch = await db.Set<IntegrationDelivery>()
+                        .AsNoTracking()
+                        .Where(x => x.ProcessedUtc == null
+                                 && (x.DoNotProcessBeforeUtc == null || x.DoNotProcessBeforeUtc <= now)
+                                 && x.Attempts < _options.MaxAttempts)
+                        .OrderBy(x => x.Event.CreatedUtc)
+                        .Take(_options.BatchSize)
+                        .Select(x => new ValueTuple<Guid, string>(x.EventId, x.Subscriber))
+                        .ToArrayAsync(stoppingToken);
+                }
+
+                foreach (var item in batch)
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var db = _options.ResolveDbContext!(scope.ServiceProvider);
+                    var delivery = await db.Set<IntegrationDelivery>()
+                        .Include(d => d.Event)
+                        .FirstOrDefaultAsync(d => d.EventId == item.EventId && d.Subscriber == item.Subscriber, stoppingToken);
+
+                    if (delivery == null || delivery.ProcessedUtc != null)
+                    {
+                        continue;
+                    }
+                    if (delivery.DoNotProcessBeforeUtc.HasValue && delivery.DoNotProcessBeforeUtc > DateTime.UtcNow)
+                    {
+                        continue;
+                    }
+
+                    using var transaction = await db.Database.BeginTransactionAsync(stoppingToken);
+                    var sw = Stopwatch.StartNew();
+                    try
+                    {
+                        if (!_eventTypeRegistry.TryResolve(delivery.Event.Name, delivery.Event.Version, out var clrType))
+                        {
+                            delivery.Attempts++;
+                            delivery.DoNotProcessBeforeUtc = DateTime.UtcNow.AddSeconds(30);
+                            await db.SaveChangesAsync(stoppingToken);
+                            await transaction.CommitAsync(stoppingToken);
+                            continue;
+                        }
+
+                        var envelopeType = typeof(EventEnvelope<>).MakeGenericType(clrType);
+                        var envelope = JsonEventSerializer.Deserialize(delivery.Event.Payload, envelopeType);
+                        var handlerType = Type.GetType(delivery.Subscriber);
+                        if (handlerType == null)
+                        {
+                            delivery.Attempts++;
+                            delivery.DoNotProcessBeforeUtc = DateTime.UtcNow.AddSeconds(30);
+                            await db.SaveChangesAsync(stoppingToken);
+                            await transaction.CommitAsync(stoppingToken);
+                            continue;
+                        }
+
+                        var handler = scope.ServiceProvider.GetRequiredService(handlerType);
+                        var method = handlerType.GetMethod("Handle");
+                        await (Task)method!.Invoke(handler, new object?[] { envelope!, stoppingToken })!;
+
+                        delivery.ProcessedUtc = DateTime.UtcNow;
+                        await db.SaveChangesAsync(stoppingToken);
+
+                        var remaining = await db.Set<IntegrationDelivery>()
+                            .Where(d => d.EventId == delivery.EventId && d.ProcessedUtc == null)
+                            .AnyAsync(stoppingToken);
+                        if (!remaining)
+                        {
+                            delivery.Event.ProcessedUtc = DateTime.UtcNow;
+                            await db.SaveChangesAsync(stoppingToken);
+                        }
+
+                        await transaction.CommitAsync(stoppingToken);
+                        sw.Stop();
+                        EventsMeters.OutboxMessagesProcessed.Add(1);
+                        EventsMeters.OutboxDispatchDurationMs.Record(sw.Elapsed.TotalMilliseconds);
+                    }
+                    catch (Exception ex)
+                    {
+                        try
+                        {
+                            await transaction.RollbackAsync(stoppingToken);
+                        }
+                        catch { }
+                        delivery.Attempts++;
+                        delivery.DoNotProcessBeforeUtc = DateTime.UtcNow.AddSeconds(30);
+                        await db.SaveChangesAsync(stoppingToken);
+                        sw.Stop();
+                        EventsMeters.OutboxMessagesFailed.Add(1);
+                        EventsMeters.OutboxDispatchDurationMs.Record(sw.Elapsed.TotalMilliseconds);
+                        _logger.LogError(ex, "Integration delivery failed for {EventId} -> {Subscriber}", delivery.EventId, delivery.Subscriber);
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "IntegrationDispatcher loop error");
+            }
+
+            if (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(_options.PollIntervalMs, stoppingToken);
+                }
+                catch (OperationCanceledException) { }
+            }
+        }
+    }
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IntegrationOutbox.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/IntegrationOutbox.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// Default implementation of <see cref="IIntegrationOutbox"/> which stores
+/// integration events in the database.
+/// </summary>
+public class IntegrationOutbox : IIntegrationOutbox
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly OutboxOptions _options;
+
+    public IntegrationOutbox(IServiceScopeFactory scopeFactory, IOptions<OutboxOptions> options)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options.Value;
+    }
+
+    public async Task<Guid> Enqueue<T>(EventEnvelope<T> envelope, CancellationToken ct = default)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = _options.ResolveDbContext!(scope.ServiceProvider);
+
+        var message = new OutboxIntegrationEvent
+        {
+            Id = envelope.EventId,
+            Name = envelope.Name,
+            Version = envelope.Version,
+            TenantId = envelope.TenantId,
+            Username = envelope.Username,
+            OccurredUtc = envelope.OccurredUtc,
+            CorrelationId = envelope.CorrelationId,
+            CausationId = envelope.CausationId,
+            Payload = JsonEventSerializer.Serialize(envelope),
+            CreatedUtc = DateTime.UtcNow,
+            Attempts = 0
+        };
+
+        db.Set<OutboxIntegrationEvent>().Add(message);
+        await db.SaveChangesAsync(ct);
+        return message.Id;
+    }
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/OutboxDispatcher.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/OutboxDispatcher.cs
@@ -47,7 +47,7 @@ public sealed class OutboxDispatcher : BackgroundService
                     var context = _options.ResolveDbContext!(scope.ServiceProvider);
                     var now = DateTime.UtcNow;
 
-                    batch = await context.Set<OutboxMessage>()
+                    batch = await context.Set<OutboxDomainMessage>()
                         .AsNoTracking()
                         .Where(x => x.ProcessedUtc == null
                                  && (x.DoNotProcessBeforeUtc == null || x.DoNotProcessBeforeUtc <= now)
@@ -65,7 +65,7 @@ public sealed class OutboxDispatcher : BackgroundService
                     var context = _options.ResolveDbContext!(scope.ServiceProvider);
 
                     // (re)load the message in this context
-                    var message = await context.Set<OutboxMessage>().FirstOrDefaultAsync(x => x.Id == messageId, cancellationToken);
+                    var message = await context.Set<OutboxDomainMessage>().FirstOrDefaultAsync(x => x.Id == messageId, cancellationToken);
 
                     if (message is null)
                     {

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/OutboxDomainMessage.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/OutboxDomainMessage.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// Represents an outbox message that originated from a domain event. These
+/// messages are stored in the <c>OutboxDomainMessages</c> table and later
+/// dispatched by the outbox dispatcher.
+/// </summary>
+public class OutboxDomainMessage
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = default!;
+    public int Version { get; set; }
+    public string TenantId { get; set; } = default!;
+    public DateTime OccurredUtc { get; set; }
+    public string? CorrelationId { get; set; }
+    public string? CausationId { get; set; }
+    public string Payload { get; set; } = default!;
+    public DateTime CreatedUtc { get; set; }
+    public DateTime? ProcessedUtc { get; set; }
+    public int Attempts { get; set; }
+    public string Username { get; set; } = default!;
+    public DateTime? DoNotProcessBeforeUtc { get; set; }
+} 

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/OutboxIntegrationEvent.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/OutboxIntegrationEvent.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace rbkApiModules.Commons.Core;
+
+/// <summary>
+/// Represents an integration event stored in the integration outbox.
+/// Each event will have deliveries for its subscribers.
+/// </summary>
+public class OutboxIntegrationEvent
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = default!;
+    public int Version { get; set; }
+    public string TenantId { get; set; } = default!;
+    public DateTime OccurredUtc { get; set; }
+    public string? CorrelationId { get; set; }
+    public string? CausationId { get; set; }
+    public string Payload { get; set; } = default!;
+    public DateTime CreatedUtc { get; set; }
+    public DateTime? ProcessedUtc { get; set; }
+    public int Attempts { get; set; }
+    public string Username { get; set; } = default!;
+    public DateTime? DoNotProcessBeforeUtc { get; set; }
+    public ICollection<IntegrationDelivery> Deliveries { get; set; } = new List<IntegrationDelivery>();
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/OutboxMessage.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Messaging/Outbox/OutboxMessage.cs
@@ -2,19 +2,11 @@ using System;
 
 namespace rbkApiModules.Commons.Core;
 
-public class OutboxMessage
+/// <summary>
+/// Legacy alias for <see cref="OutboxDomainMessage"/> to maintain backward compatibility
+/// with existing migrations and code. New code should use <see cref="OutboxDomainMessage"/>.
+/// </summary>
+[Obsolete("Use OutboxDomainMessage instead")] 
+public class OutboxMessage : OutboxDomainMessage
 {
-    public Guid Id { get; set; }
-    public string Name { get; set; } = default!;
-    public int Version { get; set; }
-    public string TenantId { get; set; } = default!;
-    public DateTime OccurredUtc { get; set; }
-    public string? CorrelationId { get; set; }
-    public string? CausationId { get; set; }
-    public string Payload { get; set; } = default!;
-    public DateTime CreatedUtc { get; set; }
-    public DateTime? ProcessedUtc { get; set; }
-    public int Attempts { get; set; }
-    public string Username { get; set; } = default!;
-    public DateTime? DoNotProcessBeforeUtc { get; set; }
-} 
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/Configurations/IntegrationDeliveryConfig.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/Configurations/IntegrationDeliveryConfig.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace rbkApiModules.Commons.Core;
+
+public class IntegrationDeliveryConfig : IEntityTypeConfiguration<IntegrationDelivery>
+{
+    public void Configure(EntityTypeBuilder<IntegrationDelivery> builder)
+    {
+        builder.ToTable("IntegrationDeliveries");
+        builder.HasKey(x => new { x.EventId, x.Subscriber });
+
+        builder.Property(x => x.Subscriber).IsRequired().HasMaxLength(500);
+        builder.Property(x => x.Attempts).IsRequired();
+        builder.Property(x => x.DoNotProcessBeforeUtc);
+        builder.Property(x => x.ProcessedUtc);
+
+        builder.HasIndex(x => x.ProcessedUtc);
+    }
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/Configurations/OutboxDomainMessageConfig.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/Configurations/OutboxDomainMessageConfig.cs
@@ -4,11 +4,11 @@ using rbkApiModules.Commons.Core;
 
 namespace rbkApiModules.Commons.Core;
 
-public class OutboxMessageConfig : IEntityTypeConfiguration<OutboxMessage>
+public class OutboxDomainMessageConfig : IEntityTypeConfiguration<OutboxDomainMessage>
 {
-    public void Configure(EntityTypeBuilder<OutboxMessage> builder)
+    public void Configure(EntityTypeBuilder<OutboxDomainMessage> builder)
     {
-        builder.ToTable("OutboxMessages");
+        builder.ToTable("OutboxDomainMessages");
         builder.HasKey(x => x.Id);
 
         builder.Property(x => x.Name).IsRequired().HasMaxLength(200);

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/Configurations/OutboxIntegrationEventConfig.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/Configurations/OutboxIntegrationEventConfig.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace rbkApiModules.Commons.Core;
+
+public class OutboxIntegrationEventConfig : IEntityTypeConfiguration<OutboxIntegrationEvent>
+{
+    public void Configure(EntityTypeBuilder<OutboxIntegrationEvent> builder)
+    {
+        builder.ToTable("OutboxIntegrationEvents");
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Name).IsRequired().HasMaxLength(200);
+        builder.Property(x => x.Version).IsRequired();
+        builder.Property(x => x.TenantId).IsRequired().HasMaxLength(100);
+        builder.Property(x => x.OccurredUtc).IsRequired();
+        builder.Property(x => x.CorrelationId).HasMaxLength(100);
+        builder.Property(x => x.CausationId).HasMaxLength(100);
+        builder.Property(x => x.Payload).IsRequired();
+        builder.Property(x => x.CreatedUtc).IsRequired();
+        builder.Property(x => x.ProcessedUtc);
+        builder.Property(x => x.Attempts).IsRequired();
+        builder.Property(x => x.DoNotProcessBeforeUtc);
+
+        builder.HasIndex(x => new { x.TenantId, x.Name, x.Version });
+        builder.HasIndex(x => x.ProcessedUtc);
+        builder.HasIndex(x => x.CreatedUtc);
+        builder.HasIndex(x => x.DoNotProcessBeforeUtc);
+
+        builder.HasMany(x => x.Deliveries)
+               .WithOne(x => x.Event)
+               .HasForeignKey(x => x.EventId);
+    }
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/Interceptors/OutboxSaveChangesInterceptor.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/Interceptors/OutboxSaveChangesInterceptor.cs
@@ -58,7 +58,7 @@ public sealed class OutboxSaveChangesInterceptor : SaveChangesInterceptor
                 var envelope = EventEnvelopeFactory.Wrap(domainEvent, _requestContext.TenantId, _requestContext.Username, _requestContext.CorrelationId, _requestContext.CausationId);
                 var payload = JsonEventSerializer.Serialize(envelope);
 
-                context.Set<OutboxMessage>().Add(new OutboxMessage
+                context.Set<OutboxDomainMessage>().Add(new OutboxDomainMessage
                 {
                     Id = envelope.EventId,
                     Name = envelope.Name,


### PR DESCRIPTION
## Summary
- introduce domain and integration outbox models with delivery tracking
- wire integration dispatcher, outbox services, and subscriber registry
- sync materials to projects via integration consumers and local copy table

## Testing
- `dotnet build PaintingProjectsManagement.Api/PaintingProjectsManagement.Api.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689c856aec308328832a110efac42de8