### PR TITLE
feat: switch to PostgreSQL and run full app via Aspire

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,7 +634,7 @@ public class Validator : AbstractValidator<Request>
 ### Prerequisites
 
 - .NET 9.0 SDK
-- SQLite (for development)
+- PostgreSQL (for development)
 - Visual Studio 2022 or VS Code
 
 ### Running the Application
@@ -657,10 +657,11 @@ public class Validator : AbstractValidator<Request>
 
 4. **Run the application**:
    ```bash
-   dotnet run --project PaintingProjectsManagement.Api
+   dotnet run --project PaintingProjectsManagement.AppHost
    ```
+   This uses .NET Aspire to start the API, PostgreSQL database and Blazor UI together.
 
-5. **Access the API**:
+5. **Access the services**:
    - API: `https://localhost:7001`
    - Swagger UI: `https://localhost:7001/swagger`
    - ReDoc: `https://localhost:7001/redoc`

--- a/back/PaintingProjectsManagement.Api/PaintingProjectsManagement.Api.csproj
+++ b/back/PaintingProjectsManagement.Api/PaintingProjectsManagement.Api.csproj
@@ -10,8 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Design" Version="1.1.6" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/back/PaintingProjectsManagement.Api/Program.cs
+++ b/back/PaintingProjectsManagement.Api/Program.cs
@@ -5,7 +5,6 @@ using PaintingProjectsManagement.Features.Paints;
 using PaintingProjectsManagement.Features.Projects;
 using PaintingProjectsManagment.Database;
 using rbkApiModules.Commons.Core;
-using rbkApiModules.Commons.Core.Helpers;
 using rbkApiModules.Commons.Core.UiDefinitions;
 using rbkApiModules.Commons.Relational;
 using rbkApiModules.Identity.Relational;
@@ -27,24 +26,15 @@ public class Program
         // Add services to the container.
         builder.Services.AddAuthorization();
 
-        string connectionString;
-        if (TestingEnvironmentChecker.IsTestingEnvironment)
-        {
-            var testDbPath = Path.Combine(AppContext.BaseDirectory, "wwwroot", "testing", $"testingdb_{Guid.NewGuid():N}.db");
-            Directory.CreateDirectory(Path.GetDirectoryName(testDbPath)!);
-            connectionString = $"Data Source={testDbPath}";
-        }
-        else
-        {
-            connectionString = "Data Source=app.db";
-        }
+        var connectionString = builder.Configuration.GetConnectionString("ppm-db")
+            ?? "Host=localhost;Port=5432;Username=postgres;Password=postgres;Database=ppm";
 
         // TODO: move to the library builder
         builder.Services.AddScoped<IRequestContext, RequestContext>();
         builder.Services.AddScoped<OutboxSaveChangesInterceptor>();
 
         builder.Services.AddDbContext<DatabaseContext>((scope, options) =>
-                options.UseSqlite(connectionString)
+                options.UseNpgsql(connectionString)
                        .EnableSensitiveDataLogging()
                        .AddInterceptors(scope.GetRequiredService<OutboxSaveChangesInterceptor>())
         );

--- a/back/PaintingProjectsManagement.Api/Services/DatabaseContextFactory.cs
+++ b/back/PaintingProjectsManagement.Api/Services/DatabaseContextFactory.cs
@@ -13,16 +13,11 @@ public class DatabaseContextFactory : IDesignTimeDbContextFactory<DatabaseContex
     {
 		try
 		{
-            var config = new ConfigurationBuilder()
-            .SetBasePath(Directory.GetCurrentDirectory())
-            .AddJsonFile("appsettings.json", optional: false)
-            .Build();
-
-            var connectionString = "Data Source=c:\\temp\\database.db";
+            var connectionString = "Host=localhost;Port=5432;Username=postgres;Password=postgres;Database=ppm";
 
             var optionsBuilder = new DbContextOptionsBuilder<DatabaseContext>();
             optionsBuilder
-                .UseSqlite(connectionString)
+                .UseNpgsql(connectionString)
                 .EnableDetailedErrors()
                 .EnableSensitiveDataLogging();
 

--- a/back/PaintingProjectsManagement.Api/appsettings.Development.json
+++ b/back/PaintingProjectsManagement.Api/appsettings.Development.json
@@ -46,5 +46,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "ppm-db": "Host=localhost;Port=5432;Username=postgres;Password=postgres;Database=ppm"
   }
 }

--- a/back/PaintingProjectsManagement.Api/appsettings.json
+++ b/back/PaintingProjectsManagement.Api/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "ppm-db": "Host=localhost;Port=5432;Username=postgres;Password=postgres;Database=ppm"
+  }
 }

--- a/back/PaintingProjectsManagement.AppHost/PaintingProjectsManagement.AppHost.csproj
+++ b/back/PaintingProjectsManagement.AppHost/PaintingProjectsManagement.AppHost.csproj
@@ -13,10 +13,12 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" Version="9.4.0" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.4.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\PaintingProjectsManagement.Api\PaintingProjectsManagement.Api.csproj" />
+    <ProjectReference Include="..\..\blazor\PaintingProjectsManagement.UI\PaintingProjectsManagement.UI\PaintingProjectsManagement.UI.csproj" />
   </ItemGroup>
 
 </Project>

--- a/back/PaintingProjectsManagement.AppHost/Program.cs
+++ b/back/PaintingProjectsManagement.AppHost/Program.cs
@@ -2,16 +2,19 @@ using PaintingProjectsManagement.AppHost;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
+var database = builder.AddPostgres("ppm-db");
+
 var apiService = builder.AddProject<Projects.PaintingProjectsManagement_Api>("ppm-api")
+    .WithReference(database)
     .WithScalarUI()
     .WithSwaggerUI()
     .WithReDoc()
     .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
     .WithEnvironment("DOTNET_ENVIRONMENT", "Development");
 
-//var blazorApp = builder.AddProject<Projects.PaintingProjectsManagement_Blazor>("ppm-blazor")
-//    .WithReference(apiService)
-//    .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
-//    .WithEnvironment("DOTNET_ENVIRONMENT", "Development");
+var blazorApp = builder.AddProject<Projects.PaintingProjectsManagement_UI>("ppm-ui")
+    .WithReference(apiService)
+    .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
+    .WithEnvironment("DOTNET_ENVIRONMENT", "Development");
 
 builder.Build().Run();

--- a/back/PaintingProjectsManagment.Database/PaintingProjectsManagment.Database.csproj
+++ b/back/PaintingProjectsManagment.Database/PaintingProjectsManagment.Database.csproj
@@ -7,8 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Design" Version="1.1.6" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- move persistence to PostgreSQL via Npgsql
- start Postgres, API and Blazor UI from Aspire host
- document PostgreSQL setup and Aspire usage

## Testing
- `dotnet test back/PaintingProjectsManagment.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689d0a9c06488328ba5a7dd454dee126