### PR TITLE
feat: add module-specific db contexts

### DIFF
--- a/back/PaintingProjectsManagement.Features.Authorization/Database/AuthDbContext.cs
+++ b/back/PaintingProjectsManagement.Features.Authorization/Database/AuthDbContext.cs
@@ -1,0 +1,63 @@
+using Microsoft.EntityFrameworkCore;
+using rbkApiModules.Authentication;
+using rbkApiModules.Commons.Core;
+using rbkApiModules.Commons.Relational;
+using rbkApiModules.Identity;
+using rbkApiModules.Identity.Core;
+
+namespace PaintingProjectsManagement.Features.Authorization;
+
+public class AuthDbContext : DbContext
+{
+    public AuthDbContext(DbContextOptions<AuthDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<User> Users => Set<User>();
+    public DbSet<Role> Roles => Set<Role>();
+    public DbSet<Claim> Claims => Set<Claim>();
+    public DbSet<Tenant> Tenants => Set<Tenant>();
+    public DbSet<RoleToClaim> RolesToClaims => Set<RoleToClaim>();
+    public DbSet<UserToRole> UsersToRoles => Set<UserToRole>();
+    public DbSet<UserToClaim> UsersToClaims => Set<UserToClaim>();
+
+    public DbSet<OutboxDomainMessage> OutboxDomainMessages => Set<OutboxDomainMessage>();
+    public DbSet<OutboxIntegrationEvent> OutboxIntegrationEvents => Set<OutboxIntegrationEvent>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(UserConfig).Assembly);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AuthDbContext).Assembly);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(OutboxDomainMessageConfig).Assembly);
+
+        SchemaRegistry.AddRelationalMapping<User>("auth", "Users");
+        SchemaRegistry.AddRelationalMapping<Role>("auth", "Roles");
+        SchemaRegistry.AddRelationalMapping<Claim>("auth", "Claims");
+        SchemaRegistry.AddRelationalMapping<Tenant>("auth", "Tenants");
+        SchemaRegistry.AddRelationalMapping<RoleToClaim>("auth", "RolesToClaims");
+        SchemaRegistry.AddRelationalMapping<UserToRole>("auth", "UsersToRoles");
+        SchemaRegistry.AddRelationalMapping<UserToClaim>("auth", "UsersToClaims");
+
+        modelBuilder.Entity<User>().ToTable("Users", "auth");
+        modelBuilder.Entity<Role>().ToTable("Roles", "auth");
+        modelBuilder.Entity<Claim>().ToTable("Claims", "auth");
+        modelBuilder.Entity<Tenant>().ToTable("Tenants", "auth");
+        modelBuilder.Entity<RoleToClaim>().ToTable("RolesToClaims", "auth");
+        modelBuilder.Entity<UserToRole>().ToTable("UsersToRoles", "auth");
+        modelBuilder.Entity<UserToClaim>().ToTable("UsersToClaims", "auth");
+
+        modelBuilder.Entity<OutboxDomainMessage>().ToTable("OutboxDomainMessages").ExcludeFromMigrations();
+        modelBuilder.Entity<OutboxIntegrationEvent>().ToTable("OutboxIntegrationEvents").ExcludeFromMigrations();
+
+        modelBuilder.AddJsonFields();
+        modelBuilder.SetupTenants();
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder.Properties<DateTime>().HaveConversion<DateTimeWithoutKindConverter>();
+        configurationBuilder.Properties<DateTime?>().HaveConversion<NullableDateTimeWithoutKindConverter>();
+    }
+}

--- a/back/PaintingProjectsManagement.Features.Authorization/PaintingProjectsManagement.Features.Authorization.csproj
+++ b/back/PaintingProjectsManagement.Features.Authorization/PaintingProjectsManagement.Features.Authorization.csproj
@@ -6,9 +6,10 @@
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\PaintingProjectsManagement.FeatureDependencies\PaintingProjectsManagement.FeatureDependencies.csproj" />
-		<ProjectReference Include="..\rbkApiModules\rbkApiModules.Identity.Core\rbkApiModules.Identity.Core.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+                <ProjectReference Include="..\PaintingProjectsManagement.FeatureDependencies\PaintingProjectsManagement.FeatureDependencies.csproj" />
+                <ProjectReference Include="..\rbkApiModules\rbkApiModules.Identity.Core\rbkApiModules.Identity.Core.csproj" />
+                <ProjectReference Include="..\rbkApiModules\rbkApiModules.Commons.Core\rbkApiModules.Commons.Core.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/back/PaintingProjectsManagement.Features.Materials/Database/MaterialsDbContext.cs
+++ b/back/PaintingProjectsManagement.Features.Materials/Database/MaterialsDbContext.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using rbkApiModules.Commons.Core;
+using rbkApiModules.Commons.Relational;
+using rbkApiModules.Identity;
+
+namespace PaintingProjectsManagement.Features.Materials;
+
+public class MaterialsDbContext : DbContext
+{
+    public MaterialsDbContext(DbContextOptions<MaterialsDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Material> Materials => Set<Material>();
+
+    public DbSet<OutboxDomainMessage> OutboxDomainMessages => Set<OutboxDomainMessage>();
+    public DbSet<OutboxIntegrationEvent> OutboxIntegrationEvents => Set<OutboxIntegrationEvent>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(MaterialsDbContext).Assembly);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(OutboxDomainMessageConfig).Assembly);
+
+        SchemaRegistry.AddRelationalMapping<Material>("materials", "materials");
+
+        modelBuilder.Entity<OutboxDomainMessage>().ToTable("OutboxDomainMessages").ExcludeFromMigrations();
+        modelBuilder.Entity<OutboxIntegrationEvent>().ToTable("OutboxIntegrationEvents").ExcludeFromMigrations();
+
+        modelBuilder.AddJsonFields();
+        modelBuilder.SetupTenants();
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder.Properties<DateTime>().HaveConversion<DateTimeWithoutKindConverter>();
+        configurationBuilder.Properties<DateTime?>().HaveConversion<NullableDateTimeWithoutKindConverter>();
+    }
+}

--- a/back/PaintingProjectsManagement.Features.Models/Database/ModelsDbContext.cs
+++ b/back/PaintingProjectsManagement.Features.Models/Database/ModelsDbContext.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using rbkApiModules.Commons.Core;
+using rbkApiModules.Commons.Relational;
+using rbkApiModules.Identity;
+
+namespace PaintingProjectsManagement.Features.Models;
+
+public class ModelsDbContext : DbContext
+{
+    public ModelsDbContext(DbContextOptions<ModelsDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Model> Models => Set<Model>();
+    public DbSet<ModelCategory> Categories => Set<ModelCategory>();
+
+    public DbSet<OutboxDomainMessage> OutboxDomainMessages => Set<OutboxDomainMessage>();
+    public DbSet<OutboxIntegrationEvent> OutboxIntegrationEvents => Set<OutboxIntegrationEvent>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(ModelsDbContext).Assembly);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(OutboxDomainMessageConfig).Assembly);
+
+        SchemaRegistry.AddRelationalMapping<Model>("models", "models");
+        SchemaRegistry.AddRelationalMapping<ModelCategory>("models", "categories");
+
+        modelBuilder.Entity<OutboxDomainMessage>().ToTable("OutboxDomainMessages").ExcludeFromMigrations();
+        modelBuilder.Entity<OutboxIntegrationEvent>().ToTable("OutboxIntegrationEvents").ExcludeFromMigrations();
+
+        modelBuilder.AddJsonFields();
+        modelBuilder.SetupTenants();
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder.Properties<DateTime>().HaveConversion<DateTimeWithoutKindConverter>();
+        configurationBuilder.Properties<DateTime?>().HaveConversion<NullableDateTimeWithoutKindConverter>();
+    }
+}

--- a/back/PaintingProjectsManagement.Features.Paints/Database/PaintsDbContext.cs
+++ b/back/PaintingProjectsManagement.Features.Paints/Database/PaintsDbContext.cs
@@ -1,0 +1,44 @@
+using Microsoft.EntityFrameworkCore;
+using rbkApiModules.Commons.Core;
+using rbkApiModules.Commons.Relational;
+using rbkApiModules.Identity;
+
+namespace PaintingProjectsManagement.Features.Paints;
+
+public class PaintsDbContext : DbContext
+{
+    public PaintsDbContext(DbContextOptions<PaintsDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<PaintBrand> Brands => Set<PaintBrand>();
+    public DbSet<PaintLine> Lines => Set<PaintLine>();
+    public DbSet<PaintColor> Colors => Set<PaintColor>();
+
+    public DbSet<OutboxDomainMessage> OutboxDomainMessages => Set<OutboxDomainMessage>();
+    public DbSet<OutboxIntegrationEvent> OutboxIntegrationEvents => Set<OutboxIntegrationEvent>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(PaintsDbContext).Assembly);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(OutboxDomainMessageConfig).Assembly);
+
+        SchemaRegistry.AddRelationalMapping<PaintBrand>("paints_catalog", "brands");
+        SchemaRegistry.AddRelationalMapping<PaintLine>("paints_catalog", "lines");
+        SchemaRegistry.AddRelationalMapping<PaintColor>("paints_catalog", "colors");
+
+        modelBuilder.Entity<OutboxDomainMessage>().ToTable("OutboxDomainMessages").ExcludeFromMigrations();
+        modelBuilder.Entity<OutboxIntegrationEvent>().ToTable("OutboxIntegrationEvents").ExcludeFromMigrations();
+
+        modelBuilder.AddJsonFields();
+        modelBuilder.SetupTenants();
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder.Properties<DateTime>().HaveConversion<DateTimeWithoutKindConverter>();
+        configurationBuilder.Properties<DateTime?>().HaveConversion<NullableDateTimeWithoutKindConverter>();
+    }
+}

--- a/back/PaintingProjectsManagement.Features.Projects/Database/ProjectsDbContext.cs
+++ b/back/PaintingProjectsManagement.Features.Projects/Database/ProjectsDbContext.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore;
+using rbkApiModules.Commons.Core;
+using rbkApiModules.Commons.Relational;
+using rbkApiModules.Identity;
+using PaintingProjectsManagement.Features.Materials;
+
+namespace PaintingProjectsManagement.Features.Projects;
+
+public class ProjectsDbContext : DbContext
+{
+    public ProjectsDbContext(DbContextOptions<ProjectsDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Project> Projects => Set<Project>();
+
+    public DbSet<OutboxDomainMessage> OutboxDomainMessages => Set<OutboxDomainMessage>();
+    public DbSet<OutboxIntegrationEvent> OutboxIntegrationEvents => Set<OutboxIntegrationEvent>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(ProjectsDbContext).Assembly);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(OutboxDomainMessageConfig).Assembly);
+
+        SchemaRegistry.AddRelationalMapping<Project>("projects", "projects");
+        SchemaRegistry.AddRelationalMapping<ColorGroup>("projects", "project_color_groups");
+        SchemaRegistry.AddRelationalMapping<ColorSection>("project", "project_color_sections");
+        SchemaRegistry.AddRelationalMapping<ProjectReference>("projects", "picture_references");
+        SchemaRegistry.AddRelationalMapping<ProjectPicture>("projects", "pictures");
+        SchemaRegistry.AddRelationalMapping<MaterialForProject>("projects", "project_materials");
+        SchemaRegistry.AddRelationalMapping<ReadOnlyMaterial>("projects", "ReadOnlyMaterials");
+
+        modelBuilder.Entity<MaterialForProject>()
+            .HasOne<Material>()
+            .WithMany()
+            .HasForeignKey(x => x.MaterialId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        modelBuilder.Entity<OutboxDomainMessage>().ToTable("OutboxDomainMessages").ExcludeFromMigrations();
+        modelBuilder.Entity<OutboxIntegrationEvent>().ToTable("OutboxIntegrationEvents").ExcludeFromMigrations();
+
+        modelBuilder.AddJsonFields();
+        modelBuilder.SetupTenants();
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder.Properties<DateTime>().HaveConversion<DateTimeWithoutKindConverter>();
+        configurationBuilder.Properties<DateTime?>().HaveConversion<NullableDateTimeWithoutKindConverter>();
+    }
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Database/SchemaRegistry.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Database/SchemaRegistry.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace rbkApiModules.Commons.Relational;
+
+public static class SchemaRegistry
+{
+    private static readonly ConcurrentDictionary<Type, (string Schema, string Table)> _relationalMappings = new();
+
+    public static void AddRelationalMapping<TEntity>(string schema, string table)
+    {
+        _relationalMappings[typeof(TEntity)] = (schema, table);
+    }
+
+    public static (string Schema, string Table)? GetRelationalMapping<TEntity>()
+    {
+        return _relationalMappings.TryGetValue(typeof(TEntity), out var mapping) ? mapping : null;
+    }
+}

--- a/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/MessagingDbContext.cs
+++ b/back/rbkApiModules/rbkApiModules.Commons.Core/Events/Persistence/MessagingDbContext.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using rbkApiModules.Commons.Relational;
+
+namespace rbkApiModules.Commons.Core;
+
+public class MessagingDbContext : DbContext
+{
+    public MessagingDbContext(DbContextOptions<MessagingDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<OutboxDomainMessage> OutboxDomainMessages => Set<OutboxDomainMessage>();
+    public DbSet<OutboxIntegrationEvent> OutboxIntegrationEvents => Set<OutboxIntegrationEvent>();
+    public DbSet<InboxMessage> InboxMessages => Set<InboxMessage>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(OutboxDomainMessageConfig).Assembly);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(InboxMessageConfig).Assembly);
+
+        SchemaRegistry.AddRelationalMapping<OutboxDomainMessage>("messaging", "OutboxDomainMessages");
+        SchemaRegistry.AddRelationalMapping<OutboxIntegrationEvent>("messaging", "OutboxIntegrationEvents");
+        SchemaRegistry.AddRelationalMapping<InboxMessage>("messaging", "InboxMessages");
+
+        modelBuilder.AddJsonFields();
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder.Properties<DateTime>().HaveConversion<DateTimeWithoutKindConverter>();
+        configurationBuilder.Properties<DateTime?>().HaveConversion<NullableDateTimeWithoutKindConverter>();
+    }
+}


### PR DESCRIPTION
## Summary
- introduce SchemaRegistry for schema-aware mapping
- create feature-specific DbContext implementations for Projects, Materials, Models, Paints, Authorization
- add MessagingDbContext for inbox/outbox processing and register message DbSets in feature contexts

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689ed64caddc832891627c9281a1fbe6