### PR TITLE
feat(models): add picture management dialog

### DIFF
--- a/back/PaintingProjectsManagement.Features.Models.Tests/UseCases/Models/Model_Pictures_Tests.cs
+++ b/back/PaintingProjectsManagement.Features.Models.Tests/UseCases/Models/Model_Pictures_Tests.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Shouldly;
+using System;
+using System.Linq;
 
 namespace PaintingProjectsManagement.Features.Models.Tests;
 
@@ -150,6 +152,20 @@ public class Model_Pictures_Tests
 
         // Assert
         response.ShouldHaveErrors(System.Net.HttpStatusCode.BadRequest, "Base64 image content is required.");
+    }
+
+    [Test, NotInParallel(Order = 7)]
+    public async Task Delete_Model_Picture_Should_Remove_From_Pictures_Array()
+    {
+        var model = await TestingServer.CreateContext().Set<Model>().FirstAsync(x => x.Id == _modelId);
+        var pictureUrl = model.Pictures.First();
+
+        var response = await TestingServer.DeleteAsync($"api/models/{_modelId}/picture?pictureUrl={Uri.EscapeDataString(pictureUrl)}");
+
+        response.ShouldBeSuccess();
+
+        var updated = await TestingServer.CreateContext().Set<Model>().FirstAsync(x => x.Id == _modelId);
+        updated.Pictures.ShouldNotContain(pictureUrl);
     }
 
     private async Task<Model> CreateTestModel()

--- a/back/PaintingProjectsManagement.Features.Models/Domain/Models/Model.cs
+++ b/back/PaintingProjectsManagement.Features.Models/Domain/Models/Model.cs
@@ -167,6 +167,26 @@ public class Model : TenantEntity
         RaiseDomainEvent(new ModelPicturesChanged(Id));
     }
 
+    public void RemovePicture(string picture)
+    {
+        var newPictures = Pictures.Where(x => x != picture).ToArray();
+
+        if (newPictures.Length == Pictures.Length)
+        {
+            return;
+        }
+
+        Pictures = newPictures;
+
+        if (CoverPicture == picture)
+        {
+            CoverPicture = null;
+            RaiseDomainEvent(new ModelCoverPictureChanged(Id));
+        }
+
+        RaiseDomainEvent(new ModelPicturesChanged(Id));
+    }
+
     public void Rate(int score)
     {
         var newScore = new Rating(Math.Min(Math.Max(score, 0), 5));

--- a/back/PaintingProjectsManagement.Features.Models/UseCases/Models/Builder.cs
+++ b/back/PaintingProjectsManagement.Features.Models/UseCases/Models/Builder.cs
@@ -9,7 +9,9 @@ public static class ModelsBuilder
         UpdateModel.MapEndpoint(app);
         DeleteModel.MapEndpoint(app);
         ListModels.MapEndpoint(app);
-        UploadModelPicture.MapEndpoint(app); 
+        UploadModelPicture.MapEndpoint(app);
+        PromotePictureToCover.MapEndpoint(app);
+        DeleteModelPicture.MapEndpoint(app);
         SetModelMustHave.MapEndpoint(app);
         ListPriorityModels.MapEndpoint(app);
 

--- a/back/PaintingProjectsManagement.Features.Models/UseCases/Models/Commands/DeleteModelPicture.cs
+++ b/back/PaintingProjectsManagement.Features.Models/UseCases/Models/Commands/DeleteModelPicture.cs
@@ -1,0 +1,67 @@
+namespace PaintingProjectsManagement.Features.Models;
+
+public class DeleteModelPicture : IEndpoint
+{
+    public static void MapEndpoint(IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapDelete("/api/models/{modelId}/picture", async (Guid modelId, string pictureUrl, IDispatcher dispatcher, CancellationToken cancellationToken) =>
+        {
+            var request = new Request { ModelId = modelId, PictureUrl = pictureUrl };
+            var result = await dispatcher.SendAsync(request, cancellationToken);
+
+            return ResultsMapper.FromResponse(result);
+        })
+        .Produces(StatusCodes.Status200OK)
+        .RequireAuthorization()
+        .WithName("Delete Model Picture")
+        .WithTags("Models");
+    }
+
+    public class Request : AuthenticatedRequest, ICommand
+    {
+        public Guid ModelId { get; set; }
+        public string PictureUrl { get; set; } = string.Empty;
+    }
+
+    public class Validator : SmartValidator<Request, Model>
+    {
+        public Validator(DbContext context, ILocalizationService localization) : base(context, localization)
+        {
+        }
+
+        protected override void ValidateBusinessRules()
+        {
+            RuleFor(x => x.PictureUrl)
+                .NotEmpty()
+                .WithMessage("Picture URL is required.");
+
+            RuleFor(x => x)
+                .MustAsync(async (request, cancellation) =>
+                {
+                    var model = await Context.Set<Model>().FirstOrDefaultAsync(x => x.Id == request.ModelId, cancellation);
+                    return model != null && model.Pictures.Contains(request.PictureUrl);
+                })
+                .WithMessage("The specified picture URL must exist in the model's pictures collection.");
+        }
+    }
+
+    public class Handler(DbContext _context, IFileStorage _fileStorage) : ICommandHandler<Request>
+    {
+        public async Task<CommandResponse> HandleAsync(Request request, CancellationToken cancellationToken)
+        {
+            var model = await _context.Set<Model>()
+                .FirstAsync(x => x.Id == request.ModelId, cancellationToken);
+
+            if (!string.IsNullOrEmpty(request.PictureUrl))
+            {
+                await _fileStorage.DeleteFileAsync(request.PictureUrl, cancellationToken);
+            }
+
+            model.RemovePicture(request.PictureUrl);
+
+            await _context.SaveChangesAsync(cancellationToken);
+
+            return CommandResponse.Success();
+        }
+    }
+}

--- a/back/PaintingProjectsManagement.Features.Models/UseCases/Models/Commands/UploadModelPicture.cs
+++ b/back/PaintingProjectsManagement.Features.Models/UseCases/Models/Commands/UploadModelPicture.cs
@@ -10,7 +10,7 @@ public class UploadModelPicture : IEndpoint
 
             return ResultsMapper.FromResponse(result);
         })
-        .Produces(StatusCodes.Status200OK)
+        .Produces<string>(StatusCodes.Status200OK)
         .RequireAuthorization()
         .WithName("Upload Model Picture")
         .WithTags("Models");
@@ -85,8 +85,8 @@ public class UploadModelPicture : IEndpoint
             model.AddPicture(pictureUrl);
             
             await _context.SaveChangesAsync(cancellationToken);
-            
-            return CommandResponse.Success();
+
+            return CommandResponse.Success(pictureUrl);
         }
     }
 }

--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Models/Requests/ModelRequests.cs
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Models/Requests/ModelRequests.cs
@@ -56,3 +56,19 @@ public enum FigureSize
     Normal = 10,
     Big = 20
 }
+
+public class UploadModelPictureRequest
+{
+    public Guid ModelId { get; init; }
+    public string Base64Image { get; init; } = string.Empty;
+}
+
+public class PromoteModelPictureRequest
+{
+    public Guid ModelId { get; init; }
+    public string PictureUrl { get; init; } = string.Empty;
+}
+
+public class DeleteModelPictureRequest : PromoteModelPictureRequest
+{
+}

--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Models/Services/IModelsService.cs
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Models/Services/IModelsService.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Net.Http;
 using System.Net.Http.Json;
 
 namespace PaintingProjectsManagement.UI.Modules.Models;
@@ -9,6 +11,9 @@ public interface IModelsService
     Task<ModelDetails> UpdateAsync(UpdateModelRequest request, CancellationToken cancellationToken);
     Task DeleteAsync(Guid id, CancellationToken cancellationToken);
     Task SetMustHaveAsync(Guid id, bool mustHave, CancellationToken cancellationToken);
+    Task<string> UploadPictureAsync(UploadModelPictureRequest request, CancellationToken cancellationToken);
+    Task PromotePictureToCoverAsync(PromoteModelPictureRequest request, CancellationToken cancellationToken);
+    Task DeletePictureAsync(Guid modelId, string pictureUrl, CancellationToken cancellationToken);
 }
 
 public interface IModelCategoriesService
@@ -62,6 +67,26 @@ public class ModelsService : IModelsService
     {
         var request = new { MustHave = mustHave };
         var response = await _httpClient.PutAsJsonAsync($"api/models/{id}/must-have", request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task<string> UploadPictureAsync(UploadModelPictureRequest request, CancellationToken cancellationToken)
+    {
+        var response = await _httpClient.PostAsJsonAsync("api/models/picture", request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<string>();
+        return result ?? string.Empty;
+    }
+
+    public async Task PromotePictureToCoverAsync(PromoteModelPictureRequest request, CancellationToken cancellationToken)
+    {
+        var response = await _httpClient.PostAsJsonAsync($"api/models/{request.ModelId}/promote-picture", request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task DeletePictureAsync(Guid modelId, string pictureUrl, CancellationToken cancellationToken)
+    {
+        var response = await _httpClient.DeleteAsync($"api/models/{modelId}/picture?pictureUrl={Uri.EscapeDataString(pictureUrl)}", cancellationToken);
         response.EnsureSuccessStatusCode();
     }
 }

--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Models/UI/Dialogs/ModelPicturesDialog.razor
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Models/UI/Dialogs/ModelPicturesDialog.razor
@@ -1,0 +1,94 @@
+@using MudBlazor
+@using Microsoft.AspNetCore.Components.Forms
+@using System.IO
+@using System.Linq
+@using System.Threading
+@using System
+@using PaintingProjectsManagement.UI.Modules.Models
+@namespace PaintingProjectsManagement.UI.Modules.Models.UI.Dialogs
+
+<MudDialog>
+    <DialogContent>
+        <MudStack Spacing="2">
+            <MudText Typo="Typo.h6">@Model.Name</MudText>
+            <label for="model-picture-input">
+                <MudButton Variant="Variant.Filled" Color="Color.Primary">Add Image</MudButton>
+            </label>
+            <InputFile id="model-picture-input" OnChange="OnFileSelected" style="display:none" accept="image/*" />
+            <MudGrid Class="mt-2">
+                @foreach (var picture in Model.Pictures)
+                {
+                    <MudItem xs="12" sm="6" md="4" lg="3">
+                        <MudCard Class="@GetCardClass(picture)">
+                            <MudCardContent Class="d-flex justify-center">
+                                <img src="@picture" style="max-width:100%;max-height:300px;object-fit:contain;" />
+                            </MudCardContent>
+                            <MudCardActions>
+                                <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="@(() => DeletePicture(picture))" />
+                                <MudIconButton Icon="@Icons.Material.Filled.Star" Color="@(IsCover(picture) ? Color.Warning : Color.Default)" OnClick="@(() => PromotePicture(picture))" />
+                            </MudCardActions>
+                        </MudCard>
+                    </MudItem>
+                }
+            </MudGrid>
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Close">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [Parameter] public ModelDetails Model { get; set; } = new();
+
+    [Inject] public IModelsService ModelsService { get; set; } = default!;
+    [CascadingParameter] public MudDialogInstance? MudDialog { get; set; }
+;
+    private async Task OnFileSelected(InputFileChangeEventArgs e)
+    {
+        var file = e.File;
+        using var stream = file.OpenReadStream(long.MaxValue);
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms);
+        var base64 = $"data:{file.ContentType};base64,{Convert.ToBase64String(ms.ToArray())}";
+        var url = await ModelsService.UploadPictureAsync(new UploadModelPictureRequest
+        {
+            ModelId = Model.Id,
+            Base64Image = base64
+        }, CancellationToken.None);
+
+        if (!string.IsNullOrWhiteSpace(url))
+        {
+            var list = Model.Pictures.ToList();
+            list.Add(url);
+            Model.Pictures = list.ToArray();
+        }
+    }
+
+    private async Task DeletePicture(string picture)
+    {
+        await ModelsService.DeletePictureAsync(Model.Id, picture, CancellationToken.None);
+        var list = Model.Pictures.Where(p => p != picture).ToList();
+        Model.Pictures = list.ToArray();
+        if (Model.CoverPicture == picture)
+        {
+            Model.CoverPicture = null;
+        }
+    }
+
+    private async Task PromotePicture(string picture)
+    {
+        await ModelsService.PromotePictureToCoverAsync(new PromoteModelPictureRequest
+        {
+            ModelId = Model.Id,
+            PictureUrl = picture
+        }, CancellationToken.None);
+        Model.CoverPicture = picture;
+    }
+
+    private bool IsCover(string picture) => Model.CoverPicture == picture;
+
+    private string GetCardClass(string picture) => IsCover(picture) ? "border border-2 border-primary" : string.Empty;
+
+    private void Close() => MudDialog?.Close();
+}

--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Models/UI/Pages/ModelsList.razor
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Models/UI/Pages/ModelsList.razor
@@ -52,6 +52,7 @@
                 <MudCheckBox T="bool" @bind-Checked="context.MustHave" />
             </MudTd>
             <MudTd Style="width: 10%">
+                <MudIconButton Icon="@Icons.Material.Filled.Image" OnClick="() => Pictures(context)" Color="Color.Secondary" />
                 <MudIconButton Icon="@Icons.Material.Filled.Edit" OnClick="() => Edit(context)" Color="Color.Primary" />
                 <MudIconButton Icon="@Icons.Material.Filled.Delete" OnClick="() => Delete(context)" Color="Color.Error" />
             </MudTd>
@@ -241,6 +242,15 @@
             if (index >= 0)
                 models[index] = updated;
         }
+    }
+
+    private async Task Pictures(ModelDetails model)
+    {
+        var parameters = new DialogParameters
+        {
+            ["Model"] = model
+        };
+        await DialogService.ShowAsync<ModelPicturesDialog>("Pictures", parameters);
     }
 
     private async Task Delete(ModelDetails model)


### PR DESCRIPTION
## Summary
- support removing pictures and cover updates in Model entity
- add API endpoints and services to upload, delete and promote model images
- implement dialog for managing model pictures and integrate into models list

## Testing
- `dotnet test PaintingProjectsManagment.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68adade72f388328bcf5b0f2d9431ee4