### PR TITLE
Build nav menu dynamically from registered modules

### DIFF
--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Materials/Builder.cs
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Materials/Builder.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using PaintingProjectsManagement.Blazor.Modules.Authentication;
+using PaintingProjectsManagement.UI.Modules.Shared;
 
 namespace PaintingProjectsManagement.UI.Modules.Materials;
 
@@ -7,6 +8,8 @@ public static class Builder
 {
     public static IServiceCollection AddMaterialsModule(this IServiceCollection services)
     {
+        services.AddSingleton<IModule, Menu>();
+
         services.AddScoped<IMaterialsService>(sp =>
         {
             var handler = sp.GetRequiredService<BearerDelegatingHandler>();
@@ -23,4 +26,4 @@ public static class Builder
 
         return services;
     }
-} 
+}

--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Models/Builder.cs
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Models/Builder.cs
@@ -8,6 +8,8 @@ public static class Builder
 {
     public static IServiceCollection AddModelsModule(this IServiceCollection services)
     {
+        services.AddSingleton<IModule, ModelsModule>();
+
         services.AddScoped<IModelCategoriesService>(sp =>
         {
             var handler = sp.GetRequiredService<BearerDelegatingHandler>();
@@ -37,11 +39,6 @@ public static class Builder
         });
 
         return services;
-    }
-
-    public static IModule GetModule()
-    {
-        return new ModelsModule();
     }
 }
 

--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI/Layout/NavMenu.razor
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI/Layout/NavMenu.razor
@@ -1,68 +1,23 @@
-﻿<MudNavMenu>
+@inject IEnumerable<IModule> Modules
+
+<MudNavMenu>
     <MudNavLink Href="/" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">
         Home
     </MudNavLink>
 
-    <MudNavGroup Title="Materials" Expanded="true">
-        <MudNavLink Href="/materials/library"
-                    Icon="@Icons.Material.Filled.MenuBook"
-                    Match="NavLinkMatch.Prefix">
-            Library
-        </MudNavLink>
-    </MudNavGroup>
-
-    <MudNavGroup Title="Models" Expanded="false">
-        <MudNavLink Href="/models/library"
-                    Icon="@Icons.Material.Filled.ViewInAr"
-                    Match="NavLinkMatch.Prefix">
-            Library
-        </MudNavLink>
-
-        <MudNavLink Href="/models/categories"
-                    Icon="@Icons.Material.Filled.Category"
-                    Match="NavLinkMatch.Prefix">
-            Categories
-        </MudNavLink>
-        <MudNavLink Href="/models/classification"
-                    Icon="@Icons.Material.Filled.List"
-                    Match="NavLinkMatch.Prefix">
-            Classsification
-        </MudNavLink>
-    </MudNavGroup>
-
-    <MudNavGroup Title="Paints" Expanded="false">
-        <MudNavLink Href="/paints/inventory"
-                    Icon="@Icons.Material.Filled.Inventory2"
-                    Match="NavLinkMatch.Prefix">
-            Inventory
-        </MudNavLink>
-
-        <MudNavLink Href="/paints/library"
-                    Icon="@Icons.Material.Filled.Palette"
-                    Match="NavLinkMatch.Prefix">
-            Library
-        </MudNavLink>
-
-        <MudNavLink Href="/paints/mixes"
-                    Icon="@Icons.Material.Filled.BlurCircular"
-                    Match="NavLinkMatch.Prefix">
-            Mixes
-        </MudNavLink>
-    </MudNavGroup>
-
-    <MudNavGroup Title="Projects" Expanded="false">
-        <MudNavLink Href="/projects/library"
-                    Icon="@Icons.Material.Filled.Inventory"
-                    Match="NavLinkMatch.Prefix">
-            Inventory
-        </MudNavLink>
-
-        <MudNavLink Href="/projects/gallery"
-                    Icon="@Icons.Material.Filled.Collections"
-                    Match="NavLinkMatch.Prefix">
-            Gallery
-        </MudNavLink>
-    </MudNavGroup>
+    @foreach (var module in Modules.OrderBy(m => m.Order))
+    {
+        <MudNavGroup Title="@module.Name" Icon="@module.Icon" Expanded="false">
+            @foreach (var route in module.Routes.OrderBy(r => r.Order))
+            {
+                <MudNavLink Href="@($"/{module.Route}/{route.Route}")"
+                            Icon="@route.Icon"
+                            Match="NavLinkMatch.Prefix">
+                    @route.Name
+                </MudNavLink>
+            }
+        </MudNavGroup>
+    }
 
     <MudNavLink Href="/about"
                 Icon="@Icons.Material.Filled.Info"


### PR DESCRIPTION
## Summary
- Register module menu implementations in DI for Materials and Models
- Render nav menu groups by iterating injected modules

## Testing
- `dotnet test PaintingProjectsManagement.UI.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68af026d98888328a4c0840b93909781