### PR TITLE
feat: centralize http error handling

### DIFF
--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Authentication/AuthenticationModule.cs
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Authentication/AuthenticationModule.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using PaintingProjectsManagement.UI.Modules.Shared;
 
 namespace PaintingProjectsManagement.Blazor.Modules.Authentication;
 
@@ -11,7 +12,10 @@ public static class Builder
 
         services.AddScoped<IAuthenticationService>(sp =>
         {
-            var httpClient = new HttpClient()
+            var errorHandler = sp.GetRequiredService<HttpErrorHandler>();
+            errorHandler.InnerHandler = new HttpClientHandler();
+
+            var httpClient = new HttpClient(errorHandler)
             {
                 BaseAddress = new Uri("https://localhost:7236")
             };
@@ -20,4 +24,4 @@ public static class Builder
 
         return services;
     }
-} 
+}

--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Authentication/Services/AuthenticationService.cs
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Authentication/Services/AuthenticationService.cs
@@ -21,13 +21,25 @@ public class AuthenticationService : IAuthenticationService
     {
         var response = await _httpClient.PostAsJsonAsync("api/authentication/login", request, cancellationToken);
 
-        return await response.Content.ReadFromJsonAsync<LoginResponse>();
+        if (response.IsSuccessStatusCode)
+        {
+            var result = await response.Content.ReadFromJsonAsync<LoginResponse>();
+            return result ?? new LoginResponse();
+        }
+
+        return new LoginResponse();
     }
 
     public async Task<RefreshTokenResponse> RefreshTokenAsync(RefreshTokenRequest request, CancellationToken cancellationToken)
     {
         var response = await _httpClient.PostAsJsonAsync("api/authentication/refresh-token", request, cancellationToken);
 
-        return await response.Content.ReadFromJsonAsync<RefreshTokenResponse>();
+        if (response.IsSuccessStatusCode)
+        {
+            var result = await response.Content.ReadFromJsonAsync<RefreshTokenResponse>();
+            return result ?? new RefreshTokenResponse();
+        }
+
+        return new RefreshTokenResponse();
     }
 }

--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Materials/Builder.cs
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Materials/Builder.cs
@@ -12,12 +12,13 @@ public static class Builder
 
         services.AddScoped<IMaterialsService>(sp =>
         {
-            var handler = sp.GetRequiredService<BearerDelegatingHandler>();
+            var bearer = sp.GetRequiredService<BearerDelegatingHandler>();
+            var errorHandler = sp.GetRequiredService<HttpErrorHandler>();
 
-            // Assign the inner handler (required!!!!)
-            handler.InnerHandler = new HttpClientHandler();
+            bearer.InnerHandler = new HttpClientHandler();
+            errorHandler.InnerHandler = bearer;
 
-            var httpClient = new HttpClient(handler)
+            var httpClient = new HttpClient(errorHandler)
             {
                 BaseAddress = new Uri("https://localhost:7236")
             };

--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Materials/Services/IMaterialsService.cs
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Materials/Services/IMaterialsService.cs
@@ -27,10 +27,14 @@ public class MaterialsService : IMaterialsService
       CancellationToken cancellationToken)
     {
         var response = await _httpClient.GetAsync("api/materials", cancellationToken);
-        response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<MaterialDetails>>();
-        return result;
+        if (response.IsSuccessStatusCode)
+        {
+            var result = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<MaterialDetails>>();
+            return result ?? Array.Empty<MaterialDetails>();
+        }
+
+        return Array.Empty<MaterialDetails>();
     }
 
     public async Task<MaterialDetails> CreateAsync(
@@ -38,11 +42,14 @@ public class MaterialsService : IMaterialsService
       CancellationToken cancellationToken)
     {
         var response = await _httpClient.PostAsJsonAsync("api/materials", request, cancellationToken);
-        response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<MaterialDetails>();
+        if (response.IsSuccessStatusCode)
+        {
+            var result = await response.Content.ReadFromJsonAsync<MaterialDetails>();
+            return result ?? new MaterialDetails();
+        }
 
-        return result;
+        return new MaterialDetails();
     }
 
     public async Task<MaterialDetails> UpdateAsync(
@@ -50,16 +57,18 @@ public class MaterialsService : IMaterialsService
       CancellationToken cancellationToken)
     {
         var response = await _httpClient.PutAsJsonAsync("api/materials", request, cancellationToken);
-        response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<MaterialDetails>();
-        return result;
+        if (response.IsSuccessStatusCode)
+        {
+            var result = await response.Content.ReadFromJsonAsync<MaterialDetails>();
+            return result ?? new MaterialDetails();
+        }
+
+        return new MaterialDetails();
     }
 
     public async Task DeleteAsync(Guid id, CancellationToken cancellationToken)
     {
-        var response = await _httpClient.DeleteAsync($"api/materials/{id}", cancellationToken);
-
-        response.EnsureSuccessStatusCode();
+        await _httpClient.DeleteAsync($"api/materials/{id}", cancellationToken);
     }
-} 
+}

--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Models/Builder.cs
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Models/Builder.cs
@@ -12,12 +12,13 @@ public static class Builder
 
         services.AddScoped<IModelCategoriesService>(sp =>
         {
-            var handler = sp.GetRequiredService<BearerDelegatingHandler>();
+            var bearer = sp.GetRequiredService<BearerDelegatingHandler>();
+            var errorHandler = sp.GetRequiredService<HttpErrorHandler>();
 
-            // Assign the inner handler (required!!!!)
-            handler.InnerHandler = new HttpClientHandler();
+            bearer.InnerHandler = new HttpClientHandler();
+            errorHandler.InnerHandler = bearer;
 
-            var httpClient = new HttpClient(handler)
+            var httpClient = new HttpClient(errorHandler)
             {
                 BaseAddress = new Uri("https://localhost:7236")
             };
@@ -26,12 +27,13 @@ public static class Builder
 
         services.AddScoped<IModelsService>(sp =>
         {
-            var handler = sp.GetRequiredService<BearerDelegatingHandler>();
+            var bearer = sp.GetRequiredService<BearerDelegatingHandler>();
+            var errorHandler = sp.GetRequiredService<HttpErrorHandler>();
 
-            // Assign the inner handler (required!!!!)
-            handler.InnerHandler = new HttpClientHandler();
+            bearer.InnerHandler = new HttpClientHandler();
+            errorHandler.InnerHandler = bearer;
 
-            var httpClient = new HttpClient(handler)
+            var httpClient = new HttpClient(errorHandler)
             {
                 BaseAddress = new Uri("https://localhost:7236")
             };

--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Models/Services/IModelsService.cs
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Models/Services/IModelsService.cs
@@ -37,89 +37,98 @@ public class ModelsService : IModelsService
     public async Task<IReadOnlyCollection<ModelDetails>> GetAllAsync(CancellationToken cancellationToken)
     {
         var response = await _httpClient.GetAsync("api/models", cancellationToken);
-        response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<ModelDetails>>();
-        return result ?? [];
+        if (response.IsSuccessStatusCode)
+        {
+            var result = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<ModelDetails>>();
+            return result ?? Array.Empty<ModelDetails>();
+        }
+
+        return Array.Empty<ModelDetails>();
     }
 
     public async Task<ModelDetails> CreateAsync(CreateModelRequest request, CancellationToken cancellationToken)
     {
         var response = await _httpClient.PostAsJsonAsync("api/models", request, cancellationToken);
-        response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<ModelDetails>();
-        return result ?? new ModelDetails();
+        if (response.IsSuccessStatusCode)
+        {
+            var result = await response.Content.ReadFromJsonAsync<ModelDetails>();
+            return result ?? new ModelDetails();
+        }
+
+        return new ModelDetails();
     }
 
     public async Task<ModelDetails> UpdateAsync(UpdateModelRequest request, CancellationToken cancellationToken)
     {
         var response = await _httpClient.PutAsJsonAsync("api/models", request, cancellationToken);
-        response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<ModelDetails>();
-        return result ?? new ModelDetails();
+        if (response.IsSuccessStatusCode)
+        {
+            var result = await response.Content.ReadFromJsonAsync<ModelDetails>();
+            return result ?? new ModelDetails();
+        }
+
+        return new ModelDetails();
     }
 
     public async Task DeleteAsync(Guid id, CancellationToken cancellationToken)
     {
-        var response = await _httpClient.DeleteAsync($"api/models/{id}", cancellationToken);
-        response.EnsureSuccessStatusCode();
+        await _httpClient.DeleteAsync($"api/models/{id}", cancellationToken);
     }
 
     public async Task SetMustHaveAsync(Guid id, bool mustHave, CancellationToken cancellationToken)
     {
         var request = new { Id = id, MustHave = mustHave };
-        var response = await _httpClient.PutAsJsonAsync("api/models/must-have", request, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        await _httpClient.PutAsJsonAsync("api/models/must-have", request, cancellationToken);
     }
 
     public async Task RateModelAsync(Guid id, int score, CancellationToken cancellationToken)
     {
         var request = new { Id = id, Score = score };
-        var response = await _httpClient.PostAsJsonAsync("api/models/rate", request, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        await _httpClient.PostAsJsonAsync("api/models/rate", request, cancellationToken);
     }
 
     public async Task SetBaseSizeAsync(Guid id, BaseSize baseSize, CancellationToken cancellationToken)
     {
         var request = new { Id = id, BaseSize = baseSize };
-        var response = await _httpClient.PutAsJsonAsync("api/models/base-size", request, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        await _httpClient.PutAsJsonAsync("api/models/base-size", request, cancellationToken);
     }
 
     public async Task SetFigureSizeAsync(Guid id, FigureSize figureSize, CancellationToken cancellationToken)
     {
         var request = new { Id = id, FigureSize = figureSize };
-        var response = await _httpClient.PutAsJsonAsync("api/models/figure-size", request, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        await _httpClient.PutAsJsonAsync("api/models/figure-size", request, cancellationToken);
     }
 
     public async Task SetFigureCountAsync(Guid id, int numberOfFigures, CancellationToken cancellationToken)
     {
         var request = new { Id = id, NumberOfFigures = numberOfFigures };
-        var response = await _httpClient.PutAsJsonAsync("api/models/figure-count", request, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        await _httpClient.PutAsJsonAsync("api/models/figure-count", request, cancellationToken);
     }
 
     public async Task<ModelDetails> UploadPictureAsync(UploadModelPictureRequest request, CancellationToken cancellationToken)
     {
         var response = await _httpClient.PostAsJsonAsync("api/models/picture", request, cancellationToken);
-        response.EnsureSuccessStatusCode();
-        var result = await response.Content.ReadFromJsonAsync<ModelDetails>();
-        return result;
+
+        if (response.IsSuccessStatusCode)
+        {
+            var result = await response.Content.ReadFromJsonAsync<ModelDetails>();
+            return result ?? new ModelDetails();
+        }
+
+        return new ModelDetails();
     }
 
     public async Task PromotePictureToCoverAsync(PromoteModelPictureRequest request, CancellationToken cancellationToken)
     {
-        var response = await _httpClient.PostAsJsonAsync($"api/models/{request.ModelId}/promote-picture", request, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        await _httpClient.PostAsJsonAsync($"api/models/{request.ModelId}/promote-picture", request, cancellationToken);
     }
 
     public async Task DeletePictureAsync(Guid modelId, string pictureUrl, CancellationToken cancellationToken)
     {
-        var response = await _httpClient.DeleteAsync($"api/models/{modelId}/picture?pictureUrl={Uri.EscapeDataString(pictureUrl)}", cancellationToken);
-        response.EnsureSuccessStatusCode();
+        await _httpClient.DeleteAsync($"api/models/{modelId}/picture?pictureUrl={Uri.EscapeDataString(pictureUrl)}", cancellationToken);
     }
 }
 
@@ -132,33 +141,44 @@ public class ModelCategoriesService : IModelCategoriesService
     public async Task<IReadOnlyCollection<ModelCategoryDetails>> GetAllAsync(CancellationToken cancellationToken)
     {
         var response = await _httpClient.GetAsync("api/models/categories", cancellationToken);
-        response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<ModelCategoryDetails>>();
-        return result ?? [];
+        if (response.IsSuccessStatusCode)
+        {
+            var result = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<ModelCategoryDetails>>();
+            return result ?? Array.Empty<ModelCategoryDetails>();
+        }
+
+        return Array.Empty<ModelCategoryDetails>();
     }
 
     public async Task<ModelCategoryDetails> CreateAsync(CreateModelCategoryRequest request, CancellationToken cancellationToken)
     {
         var response = await _httpClient.PostAsJsonAsync("api/models/categories", request, cancellationToken);
-        response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<ModelCategoryDetails>();
-        return result ?? new ModelCategoryDetails();
+        if (response.IsSuccessStatusCode)
+        {
+            var result = await response.Content.ReadFromJsonAsync<ModelCategoryDetails>();
+            return result ?? new ModelCategoryDetails();
+        }
+
+        return new ModelCategoryDetails();
     }
 
     public async Task<ModelCategoryDetails> UpdateAsync(UpdateModelCategoryRequest request, CancellationToken cancellationToken)
     {
         var response = await _httpClient.PutAsJsonAsync("api/models/categories", request, cancellationToken);
-        response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<ModelCategoryDetails>();
-        return result ?? new ModelCategoryDetails();
+        if (response.IsSuccessStatusCode)
+        {
+            var result = await response.Content.ReadFromJsonAsync<ModelCategoryDetails>();
+            return result ?? new ModelCategoryDetails();
+        }
+
+        return new ModelCategoryDetails();
     }
 
     public async Task DeleteAsync(Guid id, CancellationToken cancellationToken)
     {
-        var response = await _httpClient.DeleteAsync($"api/models/categories/{id}", cancellationToken);
-        response.EnsureSuccessStatusCode();
+        await _httpClient.DeleteAsync($"api/models/categories/{id}", cancellationToken);
     }
 }

--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Shared/HttpErrorHandler.cs
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Shared/HttpErrorHandler.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Mvc;
+using MudBlazor;
+
+namespace PaintingProjectsManagement.UI.Modules.Shared;
+
+public class HttpErrorHandler : DelegatingHandler
+{
+    private readonly NavigationManager _navigation;
+    private readonly ISnackbar _snackbar;
+    private readonly ProblemDetailsState _problemState;
+
+    public HttpErrorHandler(NavigationManager navigation, ISnackbar snackbar, ProblemDetailsState problemState)
+    {
+        _navigation = navigation;
+        _snackbar = snackbar;
+        _problemState = problemState;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = await base.SendAsync(request, cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return response;
+        }
+
+        switch (response.StatusCode)
+        {
+            case HttpStatusCode.Unauthorized:
+                _navigation.NavigateTo("/login", true);
+                break;
+            case HttpStatusCode.BadRequest:
+                var validation = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>(cancellationToken: cancellationToken);
+                if (validation?.Errors != null)
+                {
+                    foreach (var pair in validation.Errors)
+                    {
+                        foreach (var err in pair.Value)
+                        {
+                            _snackbar.Add(err, Severity.Error);
+                        }
+                    }
+                }
+                break;
+            case HttpStatusCode.InternalServerError:
+                var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>(cancellationToken: cancellationToken);
+                _problemState.Details = problem;
+#if DEBUG
+                _navigation.NavigateTo("/error", true);
+#else
+                _navigation.NavigateTo("/debug", true);
+#endif
+                break;
+        }
+
+        return response;
+    }
+}

--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Shared/ProblemDetailsState.cs
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.Modules.Shared/ProblemDetailsState.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace PaintingProjectsManagement.UI.Modules.Shared;
+
+public class ProblemDetailsState
+{
+    public ProblemDetails? Details { get; set; }
+}

--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI/Pages/Debug.razor
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI/Pages/Debug.razor
@@ -1,0 +1,14 @@
+@page "/debug"
+
+@inject PaintingProjectsManagement.UI.Modules.Shared.ProblemDetailsState ProblemState
+
+<h3>Debug</h3>
+
+@if (ProblemState.Details is not null)
+{
+    <pre>@System.Text.Json.JsonSerializer.Serialize(ProblemState.Details, new System.Text.Json.JsonSerializerOptions { WriteIndented = true })</pre>
+}
+else
+{
+    <p>No debug information available.</p>
+}

--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI/Pages/Error.razor
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI/Pages/Error.razor
@@ -1,0 +1,24 @@
+@page "/error"
+
+@inject PaintingProjectsManagement.UI.Modules.Shared.ProblemDetailsState ProblemState
+
+<h3>Error</h3>
+
+@if (ProblemState.Details is not null)
+{
+    <p>@ProblemState.Details.Title</p>
+    <p>@ProblemState.Details.Detail</p>
+    @if (ProblemState.Details.Extensions?.Count > 0)
+    {
+        <ul>
+        @foreach (var item in ProblemState.Details.Extensions)
+        {
+            <li>@item.Key: @item.Value</li>
+        }
+        </ul>
+    }
+}
+else
+{
+    <p>No error details available.</p>
+}

--- a/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI/Program.cs
+++ b/blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI/Program.cs
@@ -4,6 +4,7 @@ using MudBlazor.Services;
 using PaintingProjectsManagement.Blazor.Modules.Authentication;
 using PaintingProjectsManagement.UI.Modules.Materials;
 using PaintingProjectsManagement.UI.Modules.Models;
+using PaintingProjectsManagement.UI.Modules.Shared;
 
 namespace PaintingProjectsManagement.UI
 {
@@ -23,6 +24,9 @@ namespace PaintingProjectsManagement.UI
 
             // Register storage service
             builder.Services.AddScoped<IStorageService, StorageService>();
+
+            builder.Services.AddScoped<ProblemDetailsState>();
+            builder.Services.AddTransient<HttpErrorHandler>();
 
             builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 


### PR DESCRIPTION
## Summary
- add HttpErrorHandler to centralize handling of 400/401/500 responses
- store server errors for display and expose Error and Debug pages
- update services to avoid EnsureSuccessStatusCode and register new handler

## Testing
- `dotnet build blazor/PaintingProjectsManagement.UI/PaintingProjectsManagement.UI.sln` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b056e776b483289db20aff378274ef