### PR TITLE
Improve empty-state image upload dialogs layout

### DIFF
--- a/back/Features/Modules/Models/UI/UI/UI/Dialogs/ModelPicturesDialog.razor
+++ b/back/Features/Modules/Models/UI/UI/UI/Dialogs/ModelPicturesDialog.razor
@@ -8,7 +8,7 @@
 
 @namespace PaintingProjectsManagement.UI.Modules.Models.UI.Dialogs
 
-<MudDialog Class="pics-dialog">
+<MudDialog Class="@GetDialogClass()">
   <DialogContent>
     <MudStack Spacing="2">
       <MudFileUpload T="IBrowserFile" FilesChanged="UploadFiles">
@@ -19,33 +19,46 @@
         </ActivatorContent>
       </MudFileUpload>
 
-            <MudGrid Class="cards-grid">
-                @foreach (var picture in _vm.Pictures)
-                {
-                    <MudItem xs="12" sm="6" md="4" lg="3">
-                        <MudCard Class=@($"pic-card {(IsCover(picture) ? "is-cover" : "")}")>
-                            @if (IsCover(picture))
-                            {
-                                <div class="cover-ribbon">COVER</div>
-                            }
+            @if (HasPictures)
+            {
+                <MudGrid Class="cards-grid">
+                    @foreach (var picture in _vm.Pictures)
+                    {
+                        <MudItem xs="12" sm="6" md="4" lg="3">
+                            <MudCard Class=@($"pic-card {(IsCover(picture) ? "is-cover" : "")}")>
+                                @if (IsCover(picture))
+                                {
+                                    <div class="cover-ribbon">COVER</div>
+                                }
 
-                            <MudCardContent Class="p-0">
-                                <div class="img-frame">
-                                    <img src="@GetPictureAddress(picture)" alt="picture" class="img-fit" />
-                                </div>
-                            </MudCardContent>
+                                <MudCardContent Class="p-0">
+                                    <div class="img-frame">
+                                        <img src="@GetPictureAddress(picture)" alt="picture" class="img-fit" />
+                                    </div>
+                                </MudCardContent>
 
-                            <MudCardActions Class="pic-actions">
-                                <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
-                                               OnClick="@(() => DeletePicture(picture))" />
-                                <MudIconButton Icon="@Icons.Material.Filled.Star"
-                                               Color="@(IsCover(picture) ? Color.Warning : Color.Default)"
-                                               OnClick="@(() => PromotePicture(picture))" />
-                            </MudCardActions>
-                        </MudCard>
-                    </MudItem>
-                }
-            </MudGrid>
+                                <MudCardActions Class="pic-actions">
+                                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
+                                                   OnClick="@(() => DeletePicture(picture))" />
+                                    <MudIconButton Icon="@Icons.Material.Filled.Star"
+                                                   Color="@(IsCover(picture) ? Color.Warning : Color.Default)"
+                                                   OnClick="@(() => PromotePicture(picture))" />
+                                </MudCardActions>
+                            </MudCard>
+                        </MudItem>
+                    }
+                </MudGrid>
+            }
+            else
+            {
+                <div class="empty-gallery-state">
+                    <MudIcon Icon="@Icons.Material.Filled.Collections" Size="Size.Large" Color="Color.Default" />
+                    <MudText Typo="Typo.h6">No images uploaded yet</MudText>
+                    <MudText Typo="Typo.body2" Class="empty-gallery-caption">
+                        Upload one or more files to start building this gallery.
+                    </MudText>
+                </div>
+            }
     </MudStack>
   </DialogContent>
   <DialogActions>
@@ -80,6 +93,24 @@
     private bool IsCover(string picture)
     {
         return string.Equals(_vm.CoverPicture, picture, StringComparison.Ordinal);
+    }
+
+    private bool HasPictures
+    {
+        get
+        {
+            return _vm.Pictures.Length > 0;
+        }
+    }
+
+    private string GetDialogClass()
+    {
+        if (HasPictures)
+        {
+            return "pics-dialog";
+        }
+
+        return "pics-dialog pics-dialog-empty";
     }
 
     private void Close()
@@ -197,9 +228,35 @@
         width: min(1200px, 95vw);
     }
 
+    .pics-dialog.pics-dialog-empty .mud-dialog {
+        width: min(760px, 90vw);
+    }
+
     .pics-dialog .mud-dialog-content {
         max-height: 80vh;
         overflow: auto;
+    }
+
+    .pics-dialog.pics-dialog-empty .mud-dialog-content {
+        min-height: 360px;
+    }
+
+    .empty-gallery-state {
+        min-height: 270px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        gap: 8px;
+        text-align: center;
+        border: 1px dashed var(--mud-palette-lines-default);
+        border-radius: 12px;
+        background: color-mix(in srgb, var(--mud-palette-surface) 85%, #ffffff 15%);
+        padding: 24px;
+    }
+
+    .empty-gallery-caption {
+        max-width: 340px;
     }
 
     /* Uniform cards */

--- a/back/Features/Modules/Projects/UI/UI/UI/Dialogs/ProjectFinalPicturesDialog.razor
+++ b/back/Features/Modules/Projects/UI/UI/UI/Dialogs/ProjectFinalPicturesDialog.razor
@@ -8,7 +8,7 @@
 
 @namespace PaintingProjectsManagement.UI.Modules.Projects.UI.Dialogs
 
-<MudDialog Class="pics-dialog">
+<MudDialog Class="@GetDialogClass()">
   <DialogContent>
     <MudStack Spacing="2">
       <MudFileUpload T="IBrowserFile" FilesChanged="UploadFiles">
@@ -19,34 +19,47 @@
         </ActivatorContent>
       </MudFileUpload>
 
-            <MudGrid Class="cards-grid">
-                @foreach (var picture in _vm.Pictures)
-                {
-                    <MudItem xs="12" sm="6" md="4" lg="3">
-                        <MudCard Class=@($"pic-card {(IsCover(picture.Url) ? "is-cover" : "")}")>
-                            @if (IsCover(picture.Url))
-                            {
-                                <div class="cover-ribbon">COVER</div>
-                            }
+            @if (HasPictures)
+            {
+                <MudGrid Class="cards-grid">
+                    @foreach (var picture in _vm.Pictures)
+                    {
+                        <MudItem xs="12" sm="6" md="4" lg="3">
+                            <MudCard Class=@($"pic-card {(IsCover(picture.Url) ? "is-cover" : "")}")>
+                                @if (IsCover(picture.Url))
+                                {
+                                    <div class="cover-ribbon">COVER</div>
+                                }
 
-                            <MudCardContent Class="p-0">
-                                <div class="img-frame">
-                                    <img src="@GetPictureAddress(picture.Url)" alt="final picture" class="img-fit" />
-                                </div>
-                            </MudCardContent>
+                                <MudCardContent Class="p-0">
+                                    <div class="img-frame">
+                                        <img src="@GetPictureAddress(picture.Url)" alt="final picture" class="img-fit" />
+                                    </div>
+                                </MudCardContent>
 
-                            <MudCardActions Class="pic-actions">
-                                <MudIconButton Icon="@Icons.Material.Filled.Delete"
-                                               Color="Color.Error"
-                                               OnClick="@(() => DeletePicture(picture.Url))" />
-                                <MudIconButton Icon="@Icons.Material.Filled.Star"
-                                               Color="@(IsCover(picture.Url) ? Color.Warning : Color.Default)"
-                                               OnClick="@(() => PromotePicture(picture.Url))" />
-                            </MudCardActions>
-                        </MudCard>
-                    </MudItem>
-                }
-            </MudGrid>
+                                <MudCardActions Class="pic-actions">
+                                    <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                                   Color="Color.Error"
+                                                   OnClick="@(() => DeletePicture(picture.Url))" />
+                                    <MudIconButton Icon="@Icons.Material.Filled.Star"
+                                                   Color="@(IsCover(picture.Url) ? Color.Warning : Color.Default)"
+                                                   OnClick="@(() => PromotePicture(picture.Url))" />
+                                </MudCardActions>
+                            </MudCard>
+                        </MudItem>
+                    }
+                </MudGrid>
+            }
+            else
+            {
+                <div class="empty-gallery-state">
+                    <MudIcon Icon="@Icons.Material.Filled.Collections" Size="Size.Large" Color="Color.Default" />
+                    <MudText Typo="Typo.h6">No images uploaded yet</MudText>
+                    <MudText Typo="Typo.body2" Class="empty-gallery-caption">
+                        Upload one or more files to start building this gallery.
+                    </MudText>
+                </div>
+            }
     </MudStack>
   </DialogContent>
   <DialogActions>
@@ -81,6 +94,24 @@
     private bool IsCover(string pictureUrl)
     {
         return string.Equals(_vm.CoverPictureUrl, pictureUrl, StringComparison.Ordinal);
+    }
+
+    private bool HasPictures
+    {
+        get
+        {
+            return _vm.Pictures.Length > 0;
+        }
+    }
+
+    private string GetDialogClass()
+    {
+        if (HasPictures)
+        {
+            return "pics-dialog";
+        }
+
+        return "pics-dialog pics-dialog-empty";
     }
 
     private async Task UploadFiles(IBrowserFile file)
@@ -177,9 +208,35 @@
         width: min(1200px, 95vw);
     }
 
+    .pics-dialog.pics-dialog-empty .mud-dialog {
+        width: min(760px, 90vw);
+    }
+
     .pics-dialog .mud-dialog-content {
         max-height: 80vh;
         overflow: auto;
+    }
+
+    .pics-dialog.pics-dialog-empty .mud-dialog-content {
+        min-height: 360px;
+    }
+
+    .empty-gallery-state {
+        min-height: 270px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        gap: 8px;
+        text-align: center;
+        border: 1px dashed var(--mud-palette-lines-default);
+        border-radius: 12px;
+        background: color-mix(in srgb, var(--mud-palette-surface) 85%, #ffffff 15%);
+        padding: 24px;
+    }
+
+    .empty-gallery-caption {
+        max-width: 340px;
     }
 
     .pic-card {

--- a/back/Features/Modules/Projects/UI/UI/UI/Dialogs/ProjectReferencePicturesDialog.razor
+++ b/back/Features/Modules/Projects/UI/UI/UI/Dialogs/ProjectReferencePicturesDialog.razor
@@ -8,7 +8,7 @@
 
 @namespace PaintingProjectsManagement.UI.Modules.Projects.UI.Dialogs
 
-<MudDialog Class="pics-dialog">
+<MudDialog Class="@GetDialogClass()">
   <DialogContent>
     <MudStack Spacing="2">
       <MudFileUpload T="IBrowserFile" FilesChanged="UploadFiles">
@@ -19,33 +19,46 @@
         </ActivatorContent>
       </MudFileUpload>
 
-            <MudGrid Class="cards-grid">
-                @foreach (var reference in _vm.References)
-                {
-                    <MudItem xs="12" sm="6" md="4" lg="3">
-                        <MudCard Class=@($"pic-card {(IsCover(reference) ? "is-cover" : "")}")>
-                            @if (IsCover(reference))
-                            {
-                                <div class="cover-ribbon">COVER</div>
-                            }
+            @if (HasPictures)
+            {
+                <MudGrid Class="cards-grid">
+                    @foreach (var reference in _vm.References)
+                    {
+                        <MudItem xs="12" sm="6" md="4" lg="3">
+                            <MudCard Class=@($"pic-card {(IsCover(reference) ? "is-cover" : "")}")>
+                                @if (IsCover(reference))
+                                {
+                                    <div class="cover-ribbon">COVER</div>
+                                }
 
-                            <MudCardContent Class="p-0">
-                                <div class="img-frame">
-                                    <img src="@GetPictureAddress(reference.Url)" alt="reference picture" class="img-fit" />
-                                </div>
-                            </MudCardContent>
+                                <MudCardContent Class="p-0">
+                                    <div class="img-frame">
+                                        <img src="@GetPictureAddress(reference.Url)" alt="reference picture" class="img-fit" />
+                                    </div>
+                                </MudCardContent>
 
-                            <MudCardActions Class="pic-actions">
-                                <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
-                                               OnClick="@(() => DeletePicture(reference.Url))" />
-                                <MudIconButton Icon="@Icons.Material.Filled.Star"
-                                               Color="@(IsCover(reference) ? Color.Warning : Color.Default)"
-                                               OnClick="@(() => PromotePicture(reference.Url))" />
-                            </MudCardActions>
-                        </MudCard>
-                    </MudItem>
-                }
-            </MudGrid>
+                                <MudCardActions Class="pic-actions">
+                                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
+                                                   OnClick="@(() => DeletePicture(reference.Url))" />
+                                    <MudIconButton Icon="@Icons.Material.Filled.Star"
+                                                   Color="@(IsCover(reference) ? Color.Warning : Color.Default)"
+                                                   OnClick="@(() => PromotePicture(reference.Url))" />
+                                </MudCardActions>
+                            </MudCard>
+                        </MudItem>
+                    }
+                </MudGrid>
+            }
+            else
+            {
+                <div class="empty-gallery-state">
+                    <MudIcon Icon="@Icons.Material.Filled.Collections" Size="Size.Large" Color="Color.Default" />
+                    <MudText Typo="Typo.h6">No images uploaded yet</MudText>
+                    <MudText Typo="Typo.body2" Class="empty-gallery-caption">
+                        Upload one or more files to start building this gallery.
+                    </MudText>
+                </div>
+            }
     </MudStack>
   </DialogContent>
   <DialogActions>
@@ -81,6 +94,24 @@
     {
         ArgumentNullException.ThrowIfNull(reference);
         return string.Equals(_vm.CoverPicture, reference.Url, StringComparison.Ordinal);
+    }
+
+    private bool HasPictures
+    {
+        get
+        {
+            return _vm.References.Length > 0;
+        }
+    }
+
+    private string GetDialogClass()
+    {
+        if (HasPictures)
+        {
+            return "pics-dialog";
+        }
+
+        return "pics-dialog pics-dialog-empty";
     }
 
     private async Task UploadFiles(IBrowserFile file)
@@ -191,9 +222,35 @@
         width: min(1200px, 95vw);
     }
 
+    .pics-dialog.pics-dialog-empty .mud-dialog {
+        width: min(760px, 90vw);
+    }
+
     .pics-dialog .mud-dialog-content {
         max-height: 80vh;
         overflow: auto;
+    }
+
+    .pics-dialog.pics-dialog-empty .mud-dialog-content {
+        min-height: 360px;
+    }
+
+    .empty-gallery-state {
+        min-height: 270px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        gap: 8px;
+        text-align: center;
+        border: 1px dashed var(--mud-palette-lines-default);
+        border-radius: 12px;
+        background: color-mix(in srgb, var(--mud-palette-surface) 85%, #ffffff 15%);
+        padding: 24px;
+    }
+
+    .empty-gallery-caption {
+        max-width: 340px;
     }
 
     /* Uniform cards */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make all image upload dialogs switch to an explicit empty state when there are no images
- reduce dialog width and increase height for empty state to avoid the current overly wide/flat layout
- add a centered placeholder block with icon and guidance text while preserving existing image-grid layout when images exist

## Files changed
- `back/Features/Modules/Models/UI/UI/UI/Dialogs/ModelPicturesDialog.razor`
- `back/Features/Modules/Projects/UI/UI/UI/Dialogs/ProjectReferencePicturesDialog.razor`
- `back/Features/Modules/Projects/UI/UI/UI/Dialogs/ProjectFinalPicturesDialog.razor`

## Notes
- default (with images) dialog sizing remains unchanged
- empty state now uses a narrower width and minimum height across all upload-image dialogs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0e041c1-2a55-4875-a486-3753db886a6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0e041c1-2a55-4875-a486-3753db886a6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

