### PR TITLE
Split project cost calculation into on-demand endpoint

### DIFF
--- a/back/Features/Modules/Projects/Core/Core/Models/Domain/Money.cs
+++ b/back/Features/Modules/Projects/Core/Core/Models/Domain/Money.cs
@@ -39,6 +39,16 @@ public static class MoneyExtensions
 {
     public static async Task<Money> Convert(this Money money, string currency, ICurrencyConverter converter)
     {
+        if (string.IsNullOrWhiteSpace(money.Currency))
+        {
+            throw new InvalidOperationException("Cannot convert money with an unspecified currency.");
+        }
+
+        if (string.IsNullOrWhiteSpace(currency))
+        {
+            throw new ArgumentException("Target currency is required.", nameof(currency));
+        }
+
         if (string.Equals(money.Currency, currency, StringComparison.OrdinalIgnoreCase))
         {
             return money;
@@ -46,6 +56,6 @@ public static class MoneyExtensions
 
         var conversionRate = await converter.GetConversionRate(money.Currency, currency);
 
-        return new Money(conversionRate * money.Amount, currency);
+        return new Money(conversionRate * money.Amount, currency.Trim().ToUpperInvariant());
     }
 }

--- a/back/Features/Modules/Projects/Core/Core/Models/Domain/Money.cs
+++ b/back/Features/Modules/Projects/Core/Core/Models/Domain/Money.cs
@@ -39,23 +39,26 @@ public static class MoneyExtensions
 {
     public static async Task<Money> Convert(this Money money, string currency, ICurrencyConverter converter)
     {
-        if (string.IsNullOrWhiteSpace(money.Currency))
+        var fromCode = CurrencyCode.Normalize(money.Currency);
+        var toCode = CurrencyCode.Normalize(currency);
+
+        if (string.IsNullOrWhiteSpace(fromCode))
         {
             throw new InvalidOperationException("Cannot convert money with an unspecified currency.");
         }
 
-        if (string.IsNullOrWhiteSpace(currency))
+        if (string.IsNullOrWhiteSpace(toCode))
         {
             throw new ArgumentException("Target currency is required.", nameof(currency));
         }
 
-        if (string.Equals(money.Currency, currency, StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(fromCode, toCode, StringComparison.Ordinal))
         {
-            return money;
+            return new Money(money.Amount, toCode);
         }
 
-        var conversionRate = await converter.GetConversionRate(money.Currency, currency);
+        var conversionRate = await converter.GetConversionRate(fromCode, toCode);
 
-        return new Money(conversionRate * money.Amount, currency.Trim().ToUpperInvariant());
+        return new Money(conversionRate * money.Amount, toCode);
     }
 }

--- a/back/Features/Modules/Projects/Core/Core/Services/ProjectCostCalculator.cs
+++ b/back/Features/Modules/Projects/Core/Core/Services/ProjectCostCalculator.cs
@@ -67,11 +67,25 @@ public class ProjectCostCalculator(
             costBreakdown.Labor.Add(stepGroup.Key.ToString(), laborCost);
         }
 
+        // Group by CategoryId for resin waste, but bucket output by display name so duplicate CategoryName
+        // values (bad projection data or enum/id drift) do not throw on Dictionary.Add.
+        var materialsByCategoryName = new Dictionary<string, List<MaterialsCost>>(StringComparer.Ordinal);
+
         foreach (var categoryGroup in projectMaterials.GroupBy(x => x.Value.MaterialDefinition.CategoryId).OrderBy(x => x.Key))
         {
-            var materialsCosts = new List<MaterialsCost>();
-
             var resinWasteFactor = categoryGroup.Key == 10 ? projectSettings.ResinWasteFactor : 1.0; // TODO: Dangerous hardcoded value (resins)
+
+            var categoryName = categoryGroup.First().Value.MaterialDefinition.CategoryName;
+            if (string.IsNullOrWhiteSpace(categoryName))
+            {
+                categoryName = "Uncategorized";
+            }
+
+            if (!materialsByCategoryName.TryGetValue(categoryName, out var materialsCosts))
+            {
+                materialsCosts = new List<MaterialsCost>();
+                materialsByCategoryName[categoryName] = materialsCosts;
+            }
 
             foreach (var pm in categoryGroup)
             {
@@ -88,8 +102,11 @@ public class ProjectCostCalculator(
                     CostPerUnit = await materiaDefinition.PricePerUnit.Convert(currency, currencyConverter)
                 });
             }
+        }
 
-            costBreakdown.Materials.Add(categoryGroup.First().Value.MaterialDefinition.CategoryName, materialsCosts.AsReadOnly());
+        foreach (var (name, list) in materialsByCategoryName)
+        {
+            costBreakdown.Materials.Add(name, list.AsReadOnly());
         }
 
         return costBreakdown;

--- a/back/Features/Modules/Projects/Integrations/Integrations/Handlers/MaterialCreatedConsumer.cs
+++ b/back/Features/Modules/Projects/Integrations/Integrations/Handlers/MaterialCreatedConsumer.cs
@@ -36,12 +36,15 @@ public class MaterialCreatedConsumer : IIntegrationEventHandler<MaterialCreatedV
         }
         else
         {
+            var currency = string.IsNullOrWhiteSpace(@event.PackagePriceCurrency)
+                ? "USD"
+                : @event.PackagePriceCurrency.Trim().ToUpperInvariant();
             entity = entity with
             {
                 Name = @event.Name,
                 Unit = UnitsHelper.Convert(@event.PackageContentUnit),
                 UpdatedUtc = DateTime.UtcNow,
-                PricePerUnit = new Money(@event.PackageContentAmount == 0 ? 0 : @event.PackagePriceAmount / @event.PackageContentAmount, "USD")
+                PricePerUnit = new Money(@event.PackageContentAmount == 0 ? 0 : @event.PackagePriceAmount / @event.PackageContentAmount, currency)
             };
 
             _context.Update(entity);

--- a/back/Features/Modules/Projects/Integrations/Integrations/Handlers/MaterialUpdatedConsumer.cs
+++ b/back/Features/Modules/Projects/Integrations/Integrations/Handlers/MaterialUpdatedConsumer.cs
@@ -19,6 +19,9 @@ public class MaterialUpdatedConsumer : IIntegrationEventHandler<MaterialUpdatedV
 
         if (entity == null)
         {
+            var currency = string.IsNullOrWhiteSpace(@event.PackagePriceCurrency)
+                ? "USD"
+                : @event.PackagePriceCurrency.Trim().ToUpperInvariant();
             entity = new Material
             {
                 Tenant = envelope.TenantId,
@@ -26,7 +29,7 @@ public class MaterialUpdatedConsumer : IIntegrationEventHandler<MaterialUpdatedV
                 Name = @event.Name,
                 CategoryId = @event.CategoryId,
                 CategoryName = @event.CategoryName,
-                PricePerUnit = new Money(@event.PackageContentAmount == 0 ? 0 : @event.PackagePriceAmount / @event.PackageContentAmount, "USD"),
+                PricePerUnit = new Money(@event.PackageContentAmount == 0 ? 0 : @event.PackagePriceAmount / @event.PackageContentAmount, currency),
                 Unit = UnitsHelper.Convert(@event.PackageContentUnit),
                 UpdatedUtc = DateTime.UtcNow
             };
@@ -35,12 +38,15 @@ public class MaterialUpdatedConsumer : IIntegrationEventHandler<MaterialUpdatedV
         }
         else
         {
+            var currency = string.IsNullOrWhiteSpace(@event.PackagePriceCurrency)
+                ? "USD"
+                : @event.PackagePriceCurrency.Trim().ToUpperInvariant();
             entity = entity with
             {
                 Name = @event.Name,
                 Unit = UnitsHelper.Convert(@event.PackageContentUnit),
                 UpdatedUtc = DateTime.UtcNow,
-                PricePerUnit = new Money(@event.PackageContentAmount == 0 ? 0 : @event.PackagePriceAmount / @event.PackageContentAmount, "USD")
+                PricePerUnit = new Money(@event.PackageContentAmount == 0 ? 0 : @event.PackagePriceAmount / @event.PackageContentAmount, currency)
             };
 
             _context.Update(entity);

--- a/back/Features/Modules/Projects/UI/UI/Models/Details/ProjectDetails.cs
+++ b/back/Features/Modules/Projects/UI/UI/Models/Details/ProjectDetails.cs
@@ -25,15 +25,28 @@ public class ProjectDetails
     public UrlReference[] References { get; set; } = [];
     public UrlReference[] Pictures { get; set; } = [];
     public ColorGroupDetails[] Groups { get; set; } = Array.Empty<ColorGroupDetails>();
-    public ProjectCostDetails CostBreakdown { get; set; }  
+    public ProjectCostDetails CostBreakdown { get; set; } = ProjectCostDetails.Empty;
 }
 
 public class ProjectCostDetails
 {
     public required Guid Id { get; init; }
     public required ElectricityCostDetails Electricity { get; init; }
-    public Dictionary<string, LaborCostDetails> Labor { get; init; }
-    public Dictionary<string, IReadOnlyCollection<MaterialsCostDetails>> Materials { get; init; }
+    public Dictionary<string, LaborCostDetails> Labor { get; init; } = new();
+    public Dictionary<string, IReadOnlyCollection<MaterialsCostDetails>> Materials { get; init; } = new();
+
+    public static ProjectCostDetails Empty => new()
+    {
+        Id = Guid.Empty,
+        Electricity = new ElectricityCostDetails
+        {
+            CostPerKWh = MoneyDetails.Empty,
+            PrintingTimeInHours = 0,
+            TotalCost = MoneyDetails.Empty
+        },
+        Labor = new Dictionary<string, LaborCostDetails>(),
+        Materials = new Dictionary<string, IReadOnlyCollection<MaterialsCostDetails>>()
+    };
 }
 
 public class MaterialsCostDetails
@@ -62,6 +75,12 @@ public record MoneyDetails
 {
     public double Amount { get; set; }
     public string Currency { get; set; } = string.Empty;
+
+    public static MoneyDetails Empty => new()
+    {
+        Amount = 0,
+        Currency = "DKK"
+    };
 
     public override string ToString()
     {

--- a/back/Features/Modules/Projects/UI/UI/Services/IProjectsService.cs
+++ b/back/Features/Modules/Projects/UI/UI/Services/IProjectsService.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using PaintingProjectsManagement.Features.Inventory;
 using PaintingProjectsManagement.UI.Modules.Projects;
+using PaintingProjectsManagement.UI.Modules.Shared;
 
 namespace PaintingProjectsManagement.UI.Modules.Projects;
 
@@ -167,7 +168,13 @@ public class ProjectsService : IProjectsService
 
         if (!response.IsSuccessStatusCode)
         {
-            throw new Exception($"Failed to get project costs for project ID {projectId}. Status code: {response.StatusCode}");
+            var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>(cancellationToken: cancellationToken);
+            var detail = problem?.Detail ?? problem?.Title;
+            var suffix = string.IsNullOrWhiteSpace(detail)
+                ? $"Status code: {response.StatusCode}"
+                : detail;
+
+            throw new Exception($"Failed to get project costs for project ID {projectId}. {suffix}");
         }
 
         var result = await response.Content.ReadFromJsonAsync<ProjectCostDetails>();

--- a/back/Features/Modules/Projects/UI/UI/Services/IProjectsService.cs
+++ b/back/Features/Modules/Projects/UI/UI/Services/IProjectsService.cs
@@ -8,7 +8,9 @@ public interface IProjectsService
 {
     Task<IReadOnlyCollection<ProjectDetails>> GetAllAsync(CancellationToken cancellationToken);
 
-    Task<ProjectDetails> GetDetailsAsync(Guid projectId, CancellationToken cancellationToken, string? currency = null);
+    Task<ProjectDetails> GetDetailsAsync(Guid projectId, CancellationToken cancellationToken);
+
+    Task<ProjectCostDetails> GetCostsAsync(Guid projectId, CancellationToken cancellationToken, string? currency = null);
 
     Task<IReadOnlyCollection<CurrencyOption>> GetCurrenciesAsync(CancellationToken cancellationToken);
 
@@ -132,17 +134,9 @@ public class ProjectsService : IProjectsService
         await _httpClient.DeleteAsync($"projects/{id}", cancellationToken);
     }
 
-    public async Task<ProjectDetails> GetDetailsAsync(Guid projectId, CancellationToken cancellationToken, string? currency = null)
+    public async Task<ProjectDetails> GetDetailsAsync(Guid projectId, CancellationToken cancellationToken)
     {
-        var requestUri = $"projects/{projectId}";
-
-        if (!string.IsNullOrWhiteSpace(currency))
-        {
-            var normalizedCurrency = Uri.EscapeDataString(currency.Trim().ToUpperInvariant());
-            requestUri = $"{requestUri}?currency={normalizedCurrency}";
-        }
-
-        var response = await _httpClient.GetAsync(requestUri, cancellationToken);
+        var response = await _httpClient.GetAsync($"projects/{projectId}", cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -154,6 +148,33 @@ public class ProjectsService : IProjectsService
         if (result == null)
         {
             throw new Exception($"Project details for project ID {projectId} not found in the response.");
+        }
+
+        return result;
+    }
+
+    public async Task<ProjectCostDetails> GetCostsAsync(Guid projectId, CancellationToken cancellationToken, string? currency = null)
+    {
+        var requestUri = $"projects/{projectId}/costs";
+
+        if (!string.IsNullOrWhiteSpace(currency))
+        {
+            var normalizedCurrency = Uri.EscapeDataString(currency.Trim().ToUpperInvariant());
+            requestUri = $"{requestUri}?currency={normalizedCurrency}";
+        }
+
+        var response = await _httpClient.GetAsync(requestUri, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception($"Failed to get project costs for project ID {projectId}. Status code: {response.StatusCode}");
+        }
+
+        var result = await response.Content.ReadFromJsonAsync<ProjectCostDetails>();
+
+        if (result == null)
+        {
+            throw new Exception($"Project costs for project ID {projectId} not found in the response.");
         }
 
         return result;

--- a/back/Features/Modules/Projects/UI/UI/UI/Dialogs/ProjectCostBreakdownDialog.razor
+++ b/back/Features/Modules/Projects/UI/UI/UI/Dialogs/ProjectCostBreakdownDialog.razor
@@ -28,7 +28,7 @@
                                 <MudSelectItem T="string" Value="@currency.Code">@currency.Label</MudSelectItem>
                             }
                         </MudSelect>
-                        @if (IsReloadingBreakdown)
+                        @if (IsLoadingCosts)
                         {
                             <MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Small" />
                         }
@@ -45,8 +45,8 @@
                                 <MudAvatar Icon="@Icons.Material.Filled.ElectricBolt" Color="Color.Warning" Size="Size.Medium" />
                                 <div>
                                     <MudText Typo="Typo.caption" Color="Color.Secondary">Electricity</MudText>
-                                    <MudText Typo="Typo.h6">@Model?.CostBreakdown.Electricity.TotalCost</MudText>
-                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@Model?.CostBreakdown.Electricity.PrintingTimeInHours.ToString("N1") hours</MudText>
+                                    <MudText Typo="Typo.h6">@CostBreakdown.Electricity.TotalCost</MudText>
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@CostBreakdown.Electricity.PrintingTimeInHours.ToString("N1") hours</MudText>
                                 </div>
                             </MudStack>
                         </MudPaper>
@@ -89,18 +89,18 @@
                                     <MudListItem T="string">
                                         <MudText Typo="Typo.body2">Printing Time</MudText>
                                         <MudSpacer />
-                                        <MudText Typo="Typo.body2">@Model?.CostBreakdown.Electricity.PrintingTimeInHours.ToString("N1") h</MudText>
+                                        <MudText Typo="Typo.body2">@CostBreakdown.Electricity.PrintingTimeInHours.ToString("N1") h</MudText>
                                     </MudListItem>
                                     <MudListItem T="string">
                                         <MudText Typo="Typo.body2">Cost per kWh</MudText>
                                         <MudSpacer />
-                                        <MudText Typo="Typo.body2">@Model?.CostBreakdown.Electricity.CostPerKWh</MudText>
+                                        <MudText Typo="Typo.body2">@CostBreakdown.Electricity.CostPerKWh</MudText>
                                     </MudListItem>
                                     <MudDivider Class="my-2" />
                                     <MudListItem T="string">
                                         <MudText Typo="Typo.subtitle2" Class="font-weight-bold">Total Electricity Cost</MudText>
                                         <MudSpacer />
-                                        <MudText Typo="Typo.subtitle2" Color="Color.Success" Class="font-weight-bold">@Model?.CostBreakdown.Electricity.TotalCost</MudText>
+                                        <MudText Typo="Typo.subtitle2" Color="Color.Success" Class="font-weight-bold">@CostBreakdown.Electricity.TotalCost</MudText>
                                     </MudListItem>
                                 </MudList>
                             </MudStack>
@@ -114,9 +114,9 @@
                                     <MudIcon Icon="@Icons.Material.Filled.Engineering" Color="Color.Info" Size="Size.Medium" />
                                     <MudText Typo="Typo.h6">Duration</MudText>
                                 </MudStack>
-                                @if (Model?.CostBreakdown.Labor?.Any() == true)
+                                @if (CostBreakdown.Labor.Any())
                                 {
-                                    <MudTable Dense="true" Hover="true" Elevation="0" Items="@Model!.CostBreakdown.Labor">
+                                    <MudTable Dense="true" Hover="true" Elevation="0" Items="@CostBreakdown.Labor">
                                         <HeaderContent>
                                             <MudTh>Step</MudTh>
                                             <MudTh Align="Right">Duration</MudTh>
@@ -144,10 +144,10 @@
                                     <MudIcon Icon="@Icons.Material.Filled.Inventory2" Color="Color.Secondary" Size="Size.Medium" />
                                     <MudText Typo="Typo.h6">Materials</MudText>
                                 </MudStack>
-                                @if (Model?.CostBreakdown.Materials?.Any() == true)
+                                @if (CostBreakdown.Materials.Any())
                                 {
                                     <MudExpansionPanels Elevation="0" Dense="true">
-                                        @foreach (var category in Model!.CostBreakdown.Materials)
+                                        @foreach (var category in CostBreakdown.Materials)
                                         {
                                             <MudExpansionPanel DisableRipple="true">
                                                 <TitleContent>
@@ -201,37 +201,50 @@
     private IReadOnlyCollection<CurrencyOption> Currencies { get; set; } = [];
     private string SelectedCurrency { get; set; } = string.Empty;
     private bool IsLoadingCurrencies { get; set; }
-    private bool IsReloadingBreakdown { get; set; }
-    private bool IsCurrencySelectionDisabled => IsLoadingCurrencies || IsReloadingBreakdown || Model is null || Model.Id == Guid.Empty;
+    private ProjectCostDetails CostBreakdown { get; set; } = EmptyCostBreakdown;
+    private bool IsLoadingCosts { get; set; }
+    private bool IsCurrencySelectionDisabled => IsLoadingCurrencies || IsLoadingCosts || Model is null || Model.Id == Guid.Empty;
+    private static ProjectCostDetails EmptyCostBreakdown => new()
+    {
+        Id = Guid.Empty,
+        Electricity = new ElectricityCostDetails
+        {
+            CostPerKWh = new MoneyDetails { Amount = 0, Currency = "DKK" },
+            PrintingTimeInHours = 0,
+            TotalCost = new MoneyDetails { Amount = 0, Currency = "DKK" }
+        },
+        Labor = new Dictionary<string, LaborCostDetails>(),
+        Materials = new Dictionary<string, IReadOnlyCollection<MaterialsCostDetails>>()
+    };
 
     private MoneyDetails LaborTotal => new()
     {
-        Amount = Model?.CostBreakdown.Labor?.Values.Sum(x => x.TotalCost.Amount) ?? 0,
-        Currency = Model?.CostBreakdown.Labor?.Values.FirstOrDefault()?.TotalCost.Currency ?? DefaultCurrency
+        Amount = CostBreakdown.Labor.Values.Sum(x => x.TotalCost.Amount),
+        Currency = CostBreakdown.Labor.Values.FirstOrDefault()?.TotalCost.Currency ?? DefaultCurrency
     };
 
     private MoneyDetails MaterialsTotal => new()
     {
-        Amount = Model?.CostBreakdown.Materials?.SelectMany(x => x.Value).Sum(x => x.TotalCost.Amount) ?? 0,
-        Currency = Model?.CostBreakdown.Materials?.SelectMany(x => x.Value).FirstOrDefault()?.TotalCost.Currency ?? DefaultCurrency
+        Amount = CostBreakdown.Materials.SelectMany(x => x.Value).Sum(x => x.TotalCost.Amount),
+        Currency = CostBreakdown.Materials.SelectMany(x => x.Value).FirstOrDefault()?.TotalCost.Currency ?? DefaultCurrency
     };
 
     private MoneyDetails OverallTotal => new()
     {
-        Amount = (Model?.CostBreakdown.Electricity.TotalCost.Amount ?? 0)
-                 + (Model?.CostBreakdown.Labor?.Values.Sum(x => x.TotalCost.Amount) ?? 0)
-                 + (Model?.CostBreakdown.Materials?.SelectMany(x => x.Value).Sum(x => x.TotalCost.Amount) ?? 0),
+        Amount = CostBreakdown.Electricity.TotalCost.Amount
+                 + CostBreakdown.Labor.Values.Sum(x => x.TotalCost.Amount)
+                 + CostBreakdown.Materials.SelectMany(x => x.Value).Sum(x => x.TotalCost.Amount),
         Currency = DefaultCurrency
     };
 
-    private string DefaultCurrency => Model?.CostBreakdown.Electricity.TotalCost.Currency
-                                      ?? Model?.CostBreakdown.Labor?.Values.FirstOrDefault()?.TotalCost.Currency
-                                      ?? Model?.CostBreakdown.Materials?.SelectMany(x => x.Value).FirstOrDefault()?.TotalCost.Currency
+    private string DefaultCurrency => CostBreakdown.Electricity.TotalCost.Currency
+                                      ?? CostBreakdown.Labor.Values.FirstOrDefault()?.TotalCost.Currency
+                                      ?? CostBreakdown.Materials.SelectMany(x => x.Value).FirstOrDefault()?.TotalCost.Currency
                                       ?? "DKK";
 
-    private double TotalLaborHours => Model?.CostBreakdown.Labor?.Values.Sum(x => x.SpentHours) ?? 0;
+    private double TotalLaborHours => CostBreakdown.Labor.Values.Sum(x => x.SpentHours);
 
-    private int TotalMaterialLines => Model?.CostBreakdown.Materials?.SelectMany(x => x.Value).Count() ?? 0;
+    private int TotalMaterialLines => CostBreakdown.Materials.SelectMany(x => x.Value).Count();
 
     private string GetCategoryTotal(IReadOnlyCollection<MaterialsCostDetails> materials)
     {
@@ -250,6 +263,7 @@
         IsLoadingCurrencies = false;
 
         EnsureSelectedCurrency();
+        await LoadCostsAsync(SelectedCurrency);
     }
 
     private async Task OnCurrencyChangedAsync(string currency)
@@ -269,18 +283,12 @@
 
         try
         {
-            IsReloadingBreakdown = true;
-            Model = await ProjectsService.GetDetailsAsync(Model.Id, CancellationToken.None, normalizedCurrency);
-            EnsureSelectedCurrency();
+            await LoadCostsAsync(normalizedCurrency);
         }
         catch (Exception ex)
         {
             SelectedCurrency = previousCurrency;
             Snackbar.Add($"Could not recalculate costs in {normalizedCurrency}: {ex.Message}", Severity.Error);
-        }
-        finally
-        {
-            IsReloadingBreakdown = false;
         }
     }
 
@@ -317,6 +325,26 @@
         return string.IsNullOrWhiteSpace(currency)
             ? string.Empty
             : currency.Trim().ToUpperInvariant();
+    }
+
+    private async Task LoadCostsAsync(string? currency)
+    {
+        if (Model is null || Model.Id == Guid.Empty)
+        {
+            CostBreakdown = EmptyCostBreakdown;
+            return;
+        }
+
+        IsLoadingCosts = true;
+
+        try
+        {
+            CostBreakdown = await ProjectsService.GetCostsAsync(Model.Id, CancellationToken.None, currency);
+        }
+        finally
+        {
+            IsLoadingCosts = false;
+        }
     }
 
     private void Close() => MudDialog.Close(DialogResult.Ok(true));

--- a/back/Features/Modules/Projects/UI/UI/UI/Dialogs/ProjectCostBreakdownDialog.razor
+++ b/back/Features/Modules/Projects/UI/UI/UI/Dialogs/ProjectCostBreakdownDialog.razor
@@ -38,6 +38,13 @@
                     </MudStack>
                 </MudStack>
 
+                @if (!string.IsNullOrWhiteSpace(CostLoadError))
+                {
+                    <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Outlined">
+                        @CostLoadError
+                    </MudAlert>
+                }
+
                 <MudGrid Spacing="3">
                     <MudItem xs="12" md="4">
                         <MudPaper Class="stat-card" Elevation="1">
@@ -203,6 +210,7 @@
     private bool IsLoadingCurrencies { get; set; }
     private ProjectCostDetails CostBreakdown { get; set; } = EmptyCostBreakdown;
     private bool IsLoadingCosts { get; set; }
+    private string CostLoadError { get; set; } = string.Empty;
     private bool IsCurrencySelectionDisabled => IsLoadingCurrencies || IsLoadingCosts || Model is null || Model.Id == Guid.Empty;
     private static ProjectCostDetails EmptyCostBreakdown => new()
     {
@@ -288,7 +296,7 @@
         catch (Exception ex)
         {
             SelectedCurrency = previousCurrency;
-            Snackbar.Add($"Could not recalculate costs in {normalizedCurrency}: {ex.Message}", Severity.Error);
+            Snackbar.Add($"Could not recalculate costs in {normalizedCurrency}: {GetErrorMessage(ex)}", Severity.Error);
         }
     }
 
@@ -332,19 +340,39 @@
         if (Model is null || Model.Id == Guid.Empty)
         {
             CostBreakdown = EmptyCostBreakdown;
+            CostLoadError = string.Empty;
             return;
         }
 
         IsLoadingCosts = true;
+        CostLoadError = string.Empty;
 
         try
         {
             CostBreakdown = await ProjectsService.GetCostsAsync(Model.Id, CancellationToken.None, currency);
         }
+        catch (Exception ex)
+        {
+            CostLoadError = GetErrorMessage(ex);
+            throw;
+        }
         finally
         {
             IsLoadingCosts = false;
         }
+    }
+
+    private static string GetErrorMessage(Exception ex)
+    {
+        var message = ex.Message;
+        const string statusPrefix = "Failed to get project costs";
+
+        if (message.StartsWith(statusPrefix, StringComparison.Ordinal))
+        {
+            return "Currency conversion is temporarily unavailable. Existing costs are still shown.";
+        }
+
+        return message;
     }
 
     private void Close() => MudDialog.Close(DialogResult.Ok(true));

--- a/back/Features/Modules/Projects/UI/UI/UI/Pages/ProjectsList.razor
+++ b/back/Features/Modules/Projects/UI/UI/UI/Pages/ProjectsList.razor
@@ -70,6 +70,10 @@
                                         <MudIcon Icon="@Icons.Material.Filled.FormatColorFill" Class="mr-3" />
                                         Colors Summary
                                     </MudMenuItem>
+                                    <MudMenuItem OnClick="() => OpenCosts(project)">
+                                        <MudIcon Icon="@Icons.Material.Filled.Payments" Class="mr-3" />
+                                        Costs
+                                    </MudMenuItem>
 
                                     <MudDivider />
 
@@ -269,6 +273,14 @@
         var parameters = new DialogParameters { ["Model"] = projectDetails };
         var options = new DialogOptions { MaxWidth = MaxWidth.Large, FullWidth = true };
         DialogService.Show<UsedColorsByZoneDialog>(title: null, parameters, options);
+    }
+
+    private async Task OpenCosts(ProjectDetails project)
+    {
+        var projectDetails = await ProjectsService.GetDetailsAsync(project.Id, default);
+        var parameters = new DialogParameters { ["Model"] = projectDetails };
+        var options = new DialogOptions { MaxWidth = MaxWidth.ExtraLarge, FullWidth = true };
+        DialogService.Show<ProjectCostBreakdownDialog>(title: null, parameters, options);
     }
 
     private async Task Edit(ProjectDetails project)

--- a/back/Features/Modules/Projects/Web/Web.Tests/UseCases/Projects/Get_Project_Costs_Tests.cs
+++ b/back/Features/Modules/Projects/Web/Web.Tests/UseCases/Projects/Get_Project_Costs_Tests.cs
@@ -9,7 +9,6 @@ public class Get_Project_Costs_Tests
     public required TestingServer TestingServer { get; set; } = default!;
 
     private static Guid _testProjectId;
-    private static Guid _paintMaterialId;
     private const string Tenant = "rodrigo.basniak";
 
     [Test, NotInParallel(Order = 1)]
@@ -25,21 +24,34 @@ public class Get_Project_Costs_Tests
             await context.Set<Material>().ExecuteDeleteAsync();
             await context.SaveChangesAsync();
 
-            var paint = new Materials.Material(
+            var paintId = Guid.CreateVersion7();
+            var material = new Materials.Material(
                 Tenant,
                 "Paint Bottle",
                 MaterialCategory.Paints,
                 new Materials.Quantity(10, PackageContentUnit.Gram),
                 new Materials.Money(25, "DKK"));
 
+            var paint = new Material
+            {
+                Id = material.Id,
+                Tenant = Tenant.ToUpperInvariant(),
+                Name = "Paint Bottle",
+                CategoryId = 1,
+                CategoryName = "Paints",
+                PricePerUnit = new Money(2.5, "DKK"),
+                Unit = MaterialUnit.Gram,
+                UpdatedUtc = DateTime.UtcNow
+            };
+
+            await context.AddAsync(material);
             await context.AddAsync(paint);
             await context.AddAsync(project);
             await context.SaveChangesAsync();
 
-            _paintMaterialId = paint.Id;
             _testProjectId = project.Id;
 
-            context.Add(new MaterialForProject(project.Id, paint.Id, 4, MaterialUnit.Gram));
+            context.Add(new MaterialForProject(project.Id, material.Id, 4, MaterialUnit.Gram));
             await context.SaveChangesAsync();
         }
 
@@ -70,7 +82,7 @@ public class Get_Project_Costs_Tests
         response.Data.Labor[ProjectStepDefinition.Painting.ToString()].TotalCost.Amount.ShouldBe(375d, 0.0001d);
 
         response.Data.Materials.ShouldContainKey("Paints");
-        var paintCost = response.Data.Materials["Paints"].Single(x => x.MaterialId == _paintMaterialId);
+        var paintCost = response.Data.Materials["Paints"].Single();
         paintCost.Description.ShouldBe("Paint Bottle");
         paintCost.Quantity.ShouldBe(4d, 0.0001d);
         paintCost.TotalCost.Amount.ShouldBe(10d, 0.0001d);

--- a/back/Features/Modules/Projects/Web/Web.Tests/UseCases/Projects/Get_Project_Costs_Tests.cs
+++ b/back/Features/Modules/Projects/Web/Web.Tests/UseCases/Projects/Get_Project_Costs_Tests.cs
@@ -1,0 +1,109 @@
+using PaintingProjectsManagement.Features.Materials;
+
+namespace PaintingProjectsManagement.Features.Projects.Tests;
+
+[HumanFriendlyDisplayName]
+public class Get_Project_Costs_Tests
+{
+    [ClassDataSource<TestingServer>(Shared = SharedType.PerClass)]
+    public required TestingServer TestingServer { get; set; } = default!;
+
+    private static Guid _testProjectId;
+    private static Guid _paintMaterialId;
+    private const string Tenant = "rodrigo.basniak";
+
+    [Test, NotInParallel(Order = 1)]
+    public async Task Seed()
+    {
+        var project = new Project(Tenant, "Cost Test Project", DateTime.UtcNow.AddDays(-7), null);
+        project.AddExecutionWindow(ProjectStepDefinition.Painting, DateTime.UtcNow.AddDays(-2), 2.5);
+        project.AddExecutionWindow(ProjectStepDefinition.Printing, DateTime.UtcNow.AddDays(-1), 3.0);
+
+        using (var context = TestingServer.CreateContext())
+        {
+            await context.Set<Project>().ExecuteDeleteAsync();
+            await context.Set<Material>().ExecuteDeleteAsync();
+            await context.SaveChangesAsync();
+
+            var paint = new Materials.Material(
+                Tenant,
+                "Paint Bottle",
+                MaterialCategory.Paints,
+                new Materials.Quantity(10, PackageContentUnit.Gram),
+                new Materials.Money(25, "DKK"));
+
+            await context.AddAsync(paint);
+            await context.AddAsync(project);
+            await context.SaveChangesAsync();
+
+            _paintMaterialId = paint.Id;
+            _testProjectId = project.Id;
+
+            context.Add(new MaterialForProject(project.Id, paint.Id, 4, MaterialUnit.Gram));
+            await context.SaveChangesAsync();
+        }
+
+        await TestingServer.CacheCredentialsAsync(Tenant, "trustno1", Tenant);
+    }
+
+    [Test, NotInParallel(Order = 2)]
+    public async Task Non_Authenticated_User_Cannot_Get_Project_Costs()
+    {
+        var response = await TestingServer.GetAsync<ProjectCostDetails>($"projects/{_testProjectId}/costs");
+
+        response.ShouldHaveErrors(HttpStatusCode.Unauthorized);
+    }
+
+    [Test, NotInParallel(Order = 3)]
+    public async Task User_Can_Get_Project_Costs_On_Demand()
+    {
+        var response = await TestingServer.GetAsync<ProjectCostDetails>($"projects/{_testProjectId}/costs", Tenant);
+
+        response.ShouldBeSuccess();
+        response.Data.ShouldNotBeNull();
+        response.Data.Id.ShouldBe(_testProjectId);
+        response.Data.Electricity.TotalCost.Currency.ShouldBe("DKK");
+        response.Data.Electricity.TotalCost.Amount.ShouldBe(1.08d, 0.0001d);
+
+        response.Data.Labor.ShouldContainKey(ProjectStepDefinition.Painting.ToString());
+        response.Data.Labor[ProjectStepDefinition.Painting.ToString()].SpentHours.ShouldBe(2.5d, 0.0001d);
+        response.Data.Labor[ProjectStepDefinition.Painting.ToString()].TotalCost.Amount.ShouldBe(375d, 0.0001d);
+
+        response.Data.Materials.ShouldContainKey("Paints");
+        var paintCost = response.Data.Materials["Paints"].Single(x => x.MaterialId == _paintMaterialId);
+        paintCost.Description.ShouldBe("Paint Bottle");
+        paintCost.Quantity.ShouldBe(4d, 0.0001d);
+        paintCost.TotalCost.Amount.ShouldBe(10d, 0.0001d);
+    }
+
+    [Test, NotInParallel(Order = 4)]
+    public async Task User_Can_Request_Project_Costs_In_Another_Currency()
+    {
+        var response = await TestingServer.GetAsync<ProjectCostDetails>($"projects/{_testProjectId}/costs?currency=usd", Tenant);
+
+        response.ShouldBeSuccess();
+        response.Data.ShouldNotBeNull();
+        response.Data.Electricity.TotalCost.Currency.ShouldBe("USD");
+        response.Data.Labor[ProjectStepDefinition.Painting.ToString()].TotalCost.Currency.ShouldBe("USD");
+        response.Data.Materials["Paints"].Single().TotalCost.Currency.ShouldBe("USD");
+    }
+
+    [Test, NotInParallel(Order = 5)]
+    public async Task Project_Details_Remain_Available_Without_Cost_Recalculation()
+    {
+        var response = await TestingServer.GetAsync<ProjectDetails>($"projects/{_testProjectId}", Tenant);
+
+        response.ShouldBeSuccess();
+        response.Data.ShouldNotBeNull();
+        response.Data.Id.ShouldBe(_testProjectId);
+        response.Data.Name.ShouldBe("Cost Test Project");
+        response.Data.CostBreakdown.Id.ShouldBe(Guid.Empty);
+        response.Data.CostBreakdown.Electricity.TotalCost.Amount.ShouldBe(0d, 0.0001d);
+    }
+
+    [Test, NotInParallel(Order = 99)]
+    public async Task Cleanup()
+    {
+        await TestingServer.DisposeAsync();
+    }
+}

--- a/back/Features/Modules/Projects/Web/Web/DataTransfer/ProjectCostDetails.cs
+++ b/back/Features/Modules/Projects/Web/Web/DataTransfer/ProjectCostDetails.cs
@@ -1,11 +1,11 @@
-﻿namespace PaintingProjectsManagement.Features.Projects;
+namespace PaintingProjectsManagement.Features.Projects;
 
 public class ProjectCostDetails
 {
     public required Guid Id { get; init; }
     public required ElectricityCostDetails Electricity { get; init; }
-    public Dictionary<string, LaborCostDetails> Labor { get; init; }
-    public Dictionary<string, IReadOnlyCollection<MaterialsCostDetails>> Materials { get; init; }
+    public Dictionary<string, LaborCostDetails> Labor { get; init; } = new();
+    public Dictionary<string, IReadOnlyCollection<MaterialsCostDetails>> Materials { get; init; } = new();
 
     public static ProjectCostDetails FromModel(ProjectCostBreakdown costBreakdown)
     {
@@ -13,7 +13,7 @@ public class ProjectCostDetails
         
         return new ProjectCostDetails
         {
-            Id = costBreakdown.Id,
+            Id = costBreakdown.ProjectId,
             Electricity = ElectricityCostDetails.FromModel(costBreakdown.Electricity),
             Labor = costBreakdown.Labor?.ToDictionary(
                 kvp => kvp.Key,

--- a/back/Features/Modules/Projects/Web/Web/DataTransfer/ProjectDetails.cs
+++ b/back/Features/Modules/Projects/Web/Web/DataTransfer/ProjectDetails.cs
@@ -15,10 +15,9 @@ public class ProjectDetails
     public ColorGroupDetails[] Groups { get; set; } = Array.Empty<ColorGroupDetails>();
     public ProjectCostDetails CostBreakdown { get; set; } = ProjectCostDetails.Empty;
 
-    public static ProjectDetails FromModel(Project project, ProjectCostBreakdown projectCostBreakdown)
+    public static ProjectDetails FromModel(Project project)
     {
         ArgumentNullException.ThrowIfNull(project);
-        ArgumentNullException.ThrowIfNull(projectCostBreakdown);
 
         return new ProjectDetails
         {
@@ -30,7 +29,6 @@ public class ProjectDetails
             IsArchived = project.IsArchived,
             Steps = project.Steps.Select(x => ProjectStepDataDetails.FromModel(x)).ToArray(),
             // Materials = materialDetails ?? Array.Empty<MaterialDetails>(),
-            CostBreakdown = ProjectCostDetails.FromModel(projectCostBreakdown),
             References = project.References.Select(x => new UrlReference
             {
                 Id = x.Id,

--- a/back/Features/Modules/Projects/Web/Web/UseCases/Projects/Builder.cs
+++ b/back/Features/Modules/Projects/Web/Web/UseCases/Projects/Builder.cs
@@ -6,6 +6,7 @@ internal static class ProjectsEndpointsMap
     {
         ListProjects.MapEndpoint(app);
         GetProjectDetails.MapEndpoint(app);
+        GetProjectCosts.MapEndpoint(app);
         
         CreateProject.MapEndpoint(app);
         UpdateProject.MapEndpoint(app);

--- a/back/Features/Modules/Projects/Web/Web/UseCases/Projects/Queries/GetProjectCosts.cs
+++ b/back/Features/Modules/Projects/Web/Web/UseCases/Projects/Queries/GetProjectCosts.cs
@@ -1,7 +1,7 @@
-using System.Text.Json;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using PaintingProjectsManagement.Features.Currency;
 
 namespace PaintingProjectsManagement.Features.Projects;
 
@@ -64,44 +64,33 @@ public class GetProjectCosts : IEndpoint
                     x => x.Id == request.ProjectId && x.TenantId == request.Identity.Tenant,
                     cancellationToken);
 
+            var selectedCurrency = string.IsNullOrWhiteSpace(request.Currency)
+                ? DefaultCurrency
+                : CurrencyCode.Normalize(request.Currency);
+            if (string.IsNullOrWhiteSpace(selectedCurrency))
+            {
+                selectedCurrency = DefaultCurrency;
+            }
+
+            ProjectCostBreakdown projectCostBreakdown;
             try
             {
-                var selectedCurrency = string.IsNullOrWhiteSpace(request.Currency)
-                    ? DefaultCurrency
-                    : request.Currency.Trim().ToUpperInvariant();
-
-                var projectCostBreakdown = await projectCostCalculator.CalculateCostAsync(project.Id, selectedCurrency, cancellationToken);
-                return QueryResponse.Success(ProjectCostDetails.FromModel(projectCostBreakdown));
+                projectCostBreakdown = await projectCostCalculator.CalculateCostAsync(
+                    project.Id,
+                    selectedCurrency,
+                    cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception ex)
             {
-                logger.LogWarning(ex, "Failed to calculate project cost for project {ProjectId}. Returning empty cost breakdown.", project.Id);
-
-                // #region agent log
-                try
-                {
-                    System.IO.File.AppendAllText(
-                        "/opt/cursor/logs/debug.log",
-                        JsonSerializer.Serialize(new
-                        {
-                            hypothesisId = "H1",
-                            location = "GetProjectCosts.cs:Handler",
-                            message = ex.GetType().FullName,
-                            data = new
-                            {
-                                ex.Message,
-                                inner = ex.InnerException?.Message,
-                                projectId = project.Id,
-                                request.Currency
-                            },
-                            timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
-                        }) + "\n");
-                }
-                catch
-                {
-                    /* ignore debug log I/O errors */
-                }
-                // #endregion
+                logger.LogWarning(
+                    ex,
+                    "Failed to calculate project cost for project {ProjectId} in currency {Currency}. Returning empty cost breakdown.",
+                    project.Id,
+                    selectedCurrency);
 
                 return QueryResponse.Success(new ProjectCostDetails
                 {
@@ -110,6 +99,20 @@ public class GetProjectCosts : IEndpoint
                     Labor = ProjectCostDetails.Empty.Labor,
                     Materials = ProjectCostDetails.Empty.Materials
                 });
+            }
+
+            try
+            {
+                return QueryResponse.Success(ProjectCostDetails.FromModel(projectCostBreakdown));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(
+                    ex,
+                    "Failed to map project cost breakdown for project {ProjectId} in currency {Currency}.",
+                    project.Id,
+                    selectedCurrency);
+                throw;
             }
         }
     }

--- a/back/Features/Modules/Projects/Web/Web/UseCases/Projects/Queries/GetProjectCosts.cs
+++ b/back/Features/Modules/Projects/Web/Web/UseCases/Projects/Queries/GetProjectCosts.cs
@@ -1,0 +1,89 @@
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace PaintingProjectsManagement.Features.Projects;
+
+public class GetProjectCosts : IEndpoint
+{
+    public static void MapEndpoint(IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/projects/{projectId}/costs", async (Guid projectId, string? currency, IDispatcher dispatcher, CancellationToken cancellationToken) =>
+        {
+            var result = await dispatcher.SendAsync(new Request
+            {
+                ProjectId = projectId,
+                Currency = currency
+            }, cancellationToken);
+
+            return ResultsMapper.FromResponse(result);
+        })
+        .Produces<ProjectCostDetails>(StatusCodes.Status200OK)
+        .RequireAuthorization()
+        .WithName("Get Project Costs")
+        .WithTags("Projects");
+    }
+
+    public class Request : AuthenticatedRequest, IQuery
+    {
+        public Guid ProjectId { get; set; }
+        public string? Currency { get; set; }
+    }
+
+    internal class Validator : SmartValidator<Request, Project>
+    {
+        public Validator(DbContext context, ILocalizationService localization) : base(context, localization)
+        {
+        }
+
+        protected override void ValidateBusinessRules()
+        {
+            RuleFor(x => x.ProjectId)
+                .MustAsync(async (request, id, cancellationToken) =>
+                    await Context.Set<Project>().AnyAsync(
+                        x => x.Id == id && x.TenantId == request.Identity.Tenant,
+                        cancellationToken))
+                .WithMessage("Id references a non-existent record.");
+        }
+    }
+
+    public class Handler(
+        DbContext context,
+        IProjectCostCalculator projectCostCalculator,
+        ILogger<Handler> logger
+    ) : IQueryHandler<Request>
+    {
+        private const string DefaultCurrency = "DKK";
+
+        public async Task<QueryResponse> HandleAsync(Request request, CancellationToken cancellationToken)
+        {
+            var project = await context.Set<Project>()
+                .AsNoTracking()
+                .FirstAsync(
+                    x => x.Id == request.ProjectId && x.TenantId == request.Identity.Tenant,
+                    cancellationToken);
+
+            try
+            {
+                var selectedCurrency = string.IsNullOrWhiteSpace(request.Currency)
+                    ? DefaultCurrency
+                    : request.Currency.Trim().ToUpperInvariant();
+
+                var projectCostBreakdown = await projectCostCalculator.CalculateCostAsync(project.Id, selectedCurrency, cancellationToken);
+                return QueryResponse.Success(ProjectCostDetails.FromModel(projectCostBreakdown));
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to calculate project cost for project {ProjectId}. Returning empty cost breakdown.", project.Id);
+
+                return QueryResponse.Success(new ProjectCostDetails
+                {
+                    Id = project.Id,
+                    Electricity = ProjectCostDetails.Empty.Electricity,
+                    Labor = ProjectCostDetails.Empty.Labor,
+                    Materials = ProjectCostDetails.Empty.Materials
+                });
+            }
+        }
+    }
+}

--- a/back/Features/Modules/Projects/Web/Web/UseCases/Projects/Queries/GetProjectCosts.cs
+++ b/back/Features/Modules/Projects/Web/Web/UseCases/Projects/Queries/GetProjectCosts.cs
@@ -11,15 +11,26 @@ public class GetProjectCosts : IEndpoint
     {
         endpoints.MapGet("/projects/{projectId}/costs", async (Guid projectId, string? currency, IDispatcher dispatcher, CancellationToken cancellationToken) =>
         {
-            var result = await dispatcher.SendAsync(new Request
+            try
             {
-                ProjectId = projectId,
-                Currency = currency
-            }, cancellationToken);
+                var result = await dispatcher.SendAsync(new Request
+                {
+                    ProjectId = projectId,
+                    Currency = currency
+                }, cancellationToken);
 
-            return ResultsMapper.FromResponse(result);
+                return ResultsMapper.FromResponse(result);
+            }
+            catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException)
+            {
+                return Results.Problem(
+                    title: "Project cost recalculation unavailable",
+                    detail: ex.Message,
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
         })
         .Produces<ProjectCostDetails>(StatusCodes.Status200OK)
+        .ProducesProblem(StatusCodes.Status503ServiceUnavailable)
         .RequireAuthorization()
         .WithName("Get Project Costs")
         .WithTags("Projects");
@@ -88,17 +99,10 @@ public class GetProjectCosts : IEndpoint
             {
                 logger.LogWarning(
                     ex,
-                    "Failed to calculate project cost for project {ProjectId} in currency {Currency}. Returning empty cost breakdown.",
+                    "Failed to calculate project cost for project {ProjectId} in currency {Currency}.",
                     project.Id,
                     selectedCurrency);
-
-                return QueryResponse.Success(new ProjectCostDetails
-                {
-                    Id = project.Id,
-                    Electricity = ProjectCostDetails.Empty.Electricity,
-                    Labor = ProjectCostDetails.Empty.Labor,
-                    Materials = ProjectCostDetails.Empty.Materials
-                });
+                throw;
             }
 
             try

--- a/back/Features/Modules/Projects/Web/Web/UseCases/Projects/Queries/GetProjectCosts.cs
+++ b/back/Features/Modules/Projects/Web/Web/UseCases/Projects/Queries/GetProjectCosts.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -75,6 +76,32 @@ public class GetProjectCosts : IEndpoint
             catch (Exception ex)
             {
                 logger.LogWarning(ex, "Failed to calculate project cost for project {ProjectId}. Returning empty cost breakdown.", project.Id);
+
+                // #region agent log
+                try
+                {
+                    System.IO.File.AppendAllText(
+                        "/opt/cursor/logs/debug.log",
+                        JsonSerializer.Serialize(new
+                        {
+                            hypothesisId = "H1",
+                            location = "GetProjectCosts.cs:Handler",
+                            message = ex.GetType().FullName,
+                            data = new
+                            {
+                                ex.Message,
+                                inner = ex.InnerException?.Message,
+                                projectId = project.Id,
+                                request.Currency
+                            },
+                            timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                        }) + "\n");
+                }
+                catch
+                {
+                    /* ignore debug log I/O errors */
+                }
+                // #endregion
 
                 return QueryResponse.Success(new ProjectCostDetails
                 {

--- a/back/Features/Modules/Projects/Web/Web/UseCases/Projects/Queries/GetProjectDetails.cs
+++ b/back/Features/Modules/Projects/Web/Web/UseCases/Projects/Queries/GetProjectDetails.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 
 namespace PaintingProjectsManagement.Features.Projects;
 
@@ -8,12 +7,11 @@ public class GetProjectDetails : IEndpoint
 {
     public static void MapEndpoint(IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapGet("/projects/{projectId}", async (Guid projectId, string? currency, IDispatcher dispatcher, CancellationToken cancellationToken) =>
+        endpoints.MapGet("/projects/{projectId}", async (Guid projectId, IDispatcher dispatcher, CancellationToken cancellationToken) =>
         {
             var result = await dispatcher.SendAsync(new Request
             {
-                Id = projectId,
-                Currency = currency
+                Id = projectId
             }, cancellationToken);
             
             return ResultsMapper.FromResponse(result);
@@ -27,7 +25,6 @@ public class GetProjectDetails : IEndpoint
     public class Request : AuthenticatedRequest, IQuery
     {
         public Guid Id { get; set; }
-        public string? Currency { get; set; }
     }
 
     internal class Validator : SmartValidator<Request, Project>
@@ -47,77 +44,21 @@ public class GetProjectDetails : IEndpoint
         }
     }
 
-    public class Handler(
-        DbContext context,
-        IProjectCostCalculator projectCostCalculator,
-        ILogger<Handler> logger
-    ) : IQueryHandler<Request>
+    public class Handler(DbContext context) : IQueryHandler<Request>
     {
-        private const string DefaultCurrency = "DKK";
-
         public async Task<QueryResponse> HandleAsync(Request request, CancellationToken cancellationToken)
         {
             var project = await context.Set<Project>()
                 .Include(x => x.Steps)
                 .Include(x => x.References)
                 .Include(x => x.Pictures)
-                .Include(x => x.Materials)
                 .Include(x => x.ColorGroups)
                     .ThenInclude(x => x.Sections)
                 .FirstAsync(
                     x => x.Id == request.Id && x.TenantId == request.Identity.Tenant,
                     cancellationToken);
 
-            // TODO: Get from proper projection table in the future.
-            // Cost failures should not block project details dialogs (references/colors/matching flows).
-            ProjectCostBreakdown projectCostBreakdown;
-            try
-            {
-                var selectedCurrency = string.IsNullOrWhiteSpace(request.Currency)
-                    ? DefaultCurrency
-                    : request.Currency.Trim().ToUpperInvariant();
-
-                projectCostBreakdown = await projectCostCalculator.CalculateCostAsync(project.Id, selectedCurrency, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Failed to calculate project cost for project {ProjectId}. Returning empty cost breakdown.", project.Id);
-                projectCostBreakdown = new ProjectCostBreakdown
-                {
-                    ProjectId = project.Id,
-                    Electricity = ElectricityCost.Empty(),
-                    Labor = new Dictionary<string, LaborCost>(),
-                    Materials = new Dictionary<string, IReadOnlyCollection<MaterialsCost>>()
-                };
-            }
-
-
-            if (project.Materials.Any())
-            {
-                var materialIds = project.Materials.Select(x => x.MaterialId).ToArray();
-
-                //var materialsRequest = new GetMaterialsForProject.Request
-                //{
-                //    MaterialIds = materialIds
-                //};
-
-                //var materialsResponse = await _dispatcher.SendAsync(materialsRequest, cancellationToken);
-                
-                //if (!materialsResponse.IsValid)
-                //{
-                //    return QueryResponse.Failure(materialsResponse.Error);
-                //}
-
-                //var materialDetails = materialsResponse.Data
-                //    .Select(materialData =>
-                //    {
-                //        var projectMaterial = project.Materials.First(projectMaterial => projectMaterial.MaterialId == materialData.Id);
-                //        return MaterialDetails.FromModel(materialData, projectMaterial);
-                //    })
-                //    .ToArray();
-            }
-
-            return QueryResponse.Success(ProjectDetails.FromModel(project, projectCostBreakdown));
+            return QueryResponse.Success(ProjectDetails.FromModel(project));
         }
     }
 }

--- a/back/Features/Shared/Currency/Contracts/ICurrencyConverter.cs
+++ b/back/Features/Shared/Currency/Contracts/ICurrencyConverter.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
+using System.Net;
 
 namespace PaintingProjectsManagement.Features.Currency;
 
@@ -18,6 +19,11 @@ internal class CurrencyConverter : ICurrencyConverter
     private readonly ILogger<CurrencyConverter> _logger;
     private const string ApiBaseUrl = "https://api.frankfurter.app";
     private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
+    private static readonly TimeSpan[] RetryDelays =
+    [
+        TimeSpan.FromMilliseconds(250),
+        TimeSpan.FromMilliseconds(750)
+    ];
 
     public CurrencyConverter(HttpClient httpClient, IMemoryCache cache, ILogger<CurrencyConverter> logger)
     {
@@ -56,8 +62,7 @@ internal class CurrencyConverter : ICurrencyConverter
         {
             try
             {
-                var response = await _httpClient.GetAsync($"/latest?from={from}");
-                var content = await response.Content.ReadAsStringAsync();
+                var (response, content) = await GetLatestRatesAsync(from);
 
                 if (!response.IsSuccessStatusCode)
                 {
@@ -139,6 +144,44 @@ internal class CurrencyConverter : ICurrencyConverter
         {
             throw new InvalidOperationException($"Failed to fetch available currencies: {ex.Message}", ex);
         }
+    }
+
+    private async Task<(HttpResponseMessage Response, string Content)> GetLatestRatesAsync(string from)
+    {
+        HttpResponseMessage? lastResponse = null;
+        string lastContent = string.Empty;
+
+        for (var attempt = 0; attempt <= RetryDelays.Length; attempt++)
+        {
+            lastResponse?.Dispose();
+            lastResponse = await _httpClient.GetAsync($"/latest?from={from}");
+            lastContent = await lastResponse.Content.ReadAsStringAsync();
+
+            if (lastResponse.IsSuccessStatusCode || !ShouldRetry(lastResponse.StatusCode) || attempt == RetryDelays.Length)
+            {
+                return (lastResponse, lastContent);
+            }
+
+            _logger.LogWarning(
+                "Retrying Frankfurter latest rates request for base {From} after transient HTTP {Status}. Attempt {Attempt} of {TotalAttempts}.",
+                from,
+                (int)lastResponse.StatusCode,
+                attempt + 1,
+                RetryDelays.Length + 1);
+
+            await Task.Delay(RetryDelays[attempt]);
+        }
+
+        return (lastResponse!, lastContent);
+    }
+
+    private static bool ShouldRetry(HttpStatusCode statusCode)
+    {
+        return statusCode is HttpStatusCode.TooManyRequests
+            or HttpStatusCode.BadGateway
+            or HttpStatusCode.GatewayTimeout
+            or HttpStatusCode.ServiceUnavailable
+            or HttpStatusCode.Forbidden;
     }
 
     private class FrankfurterResponse

--- a/back/Features/Shared/Currency/Contracts/ICurrencyConverter.cs
+++ b/back/Features/Shared/Currency/Contracts/ICurrencyConverter.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -26,41 +26,117 @@ internal class CurrencyConverter : ICurrencyConverter
 
     public async Task<double> GetConversionRate(string fromCurrency, string toCurrency)
     {
-        if (fromCurrency.Equals(toCurrency, StringComparison.InvariantCultureIgnoreCase))
+        if (string.IsNullOrWhiteSpace(fromCurrency))
+        {
+            throw new ArgumentException("From currency is required.", nameof(fromCurrency));
+        }
+
+        if (string.IsNullOrWhiteSpace(toCurrency))
+        {
+            throw new ArgumentException("To currency is required.", nameof(toCurrency));
+        }
+
+        var from = fromCurrency.Trim().ToUpperInvariant();
+        var to = toCurrency.Trim().ToUpperInvariant();
+
+        if (string.Equals(from, to, StringComparison.Ordinal))
         {
             return 1.0;
         }
 
-        var cacheKey = $"conversion_rate_{fromCurrency.ToUpper()}_{toCurrency.ToUpper()}";
-        
-        if (_cache.TryGetValue(cacheKey, out double cachedRate))
+        // Cache the full ECB rate table for the base currency (one HTTP call per distinct "from"
+        // per hour). Resolves target via case-insensitive lookup instead of relying on Frankfurter's
+        // optional `to=` filter, which can behave inconsistently for some pairs or API versions.
+        var tableCacheKey = $"latest_rates_{from}";
+
+        if (!_cache.TryGetValue(tableCacheKey, out Dictionary<string, double>? ratesTable) || ratesTable is null)
         {
-            return cachedRate;
+            try
+            {
+                var response = await _httpClient.GetAsync($"/latest?from={from}");
+                var content = await response.Content.ReadAsStringAsync();
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    // #region agent log
+                    try
+                    {
+                        var snippet = content.Length > 240 ? content[..240] : content;
+                        System.IO.File.AppendAllText(
+                            "/opt/cursor/logs/debug.log",
+                            JsonSerializer.Serialize(new
+                            {
+                                hypothesisId = "H2",
+                                location = "ICurrencyConverter.cs:GetConversionRate",
+                                message = "Frankfurter non-success",
+                                data = new { from, to, status = (int)response.StatusCode, bodySnippet = snippet },
+                                timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                            }) + "\n");
+                    }
+                    catch
+                    {
+                        /* ignore debug log I/O errors */
+                    }
+                    // #endregion
+
+                    throw new InvalidOperationException(
+                        $"Frankfurter HTTP {(int)response.StatusCode} when loading rates for base {from}.");
+                }
+
+                var result = JsonSerializer.Deserialize<FrankfurterResponse>(content, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+
+                if (result?.Rates is null || result.Rates.Count == 0)
+                {
+                    throw new InvalidOperationException($"Frankfurter returned no rates for base currency {from}.");
+                }
+
+                ratesTable = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+                foreach (var kv in result.Rates)
+                {
+                    ratesTable[kv.Key] = kv.Value;
+                }
+
+                _cache.Set(tableCacheKey, ratesTable, CacheDuration);
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new InvalidOperationException($"Failed to fetch currency conversion rate: {ex.Message}", ex);
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException("Failed to parse Frankfurter currency response.", ex);
+            }
         }
 
+        if (ratesTable.TryGetValue(to, out var rate))
+        {
+            return rate;
+        }
+
+        // #region agent log
         try
         {
-            var response = await _httpClient.GetAsync($"/latest?from={fromCurrency.ToUpper()}&to={toCurrency.ToUpper()}");
-            response.EnsureSuccessStatusCode();
-
-            var content = await response.Content.ReadAsStringAsync();
-            var result = JsonSerializer.Deserialize<FrankfurterResponse>(content, new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true
-            });
-
-            if (result?.Rates != null && result.Rates.TryGetValue(toCurrency.ToUpper(), out var rate))
-            {
-                _cache.Set(cacheKey, rate, CacheDuration);
-                return rate;
-            }
-
-            throw new InvalidOperationException($"Unable to get conversion rate from {fromCurrency} to {toCurrency}");
+            System.IO.File.AppendAllText(
+                "/opt/cursor/logs/debug.log",
+                JsonSerializer.Serialize(new
+                {
+                    hypothesisId = "H2b",
+                    location = "ICurrencyConverter.cs:GetConversionRate",
+                    message = "Target currency missing in rates table",
+                    data = new { from, to, rateKeyCount = ratesTable.Count },
+                    timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                }) + "\n");
         }
-        catch (HttpRequestException ex)
+        catch
         {
-            throw new InvalidOperationException($"Failed to fetch currency conversion rate: {ex.Message}", ex);
+            /* ignore */
         }
+        // #endregion
+
+        throw new InvalidOperationException($"Unable to get conversion rate from {from} to {to}.");
     }
 
     public async Task<Dictionary<string, string>> GetAvailableCurrencies()

--- a/back/Features/Shared/Currency/Contracts/ICurrencyConverter.cs
+++ b/back/Features/Shared/Currency/Contracts/ICurrencyConverter.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 
 namespace PaintingProjectsManagement.Features.Currency;
 
@@ -14,30 +15,32 @@ internal class CurrencyConverter : ICurrencyConverter
 {
     private readonly HttpClient _httpClient;
     private readonly IMemoryCache _cache;
+    private readonly ILogger<CurrencyConverter> _logger;
     private const string ApiBaseUrl = "https://api.frankfurter.app";
     private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
 
-    public CurrencyConverter(HttpClient httpClient, IMemoryCache cache)
+    public CurrencyConverter(HttpClient httpClient, IMemoryCache cache, ILogger<CurrencyConverter> logger)
     {
         _httpClient = httpClient;
         _cache = cache;
+        _logger = logger;
         _httpClient.BaseAddress = new Uri(ApiBaseUrl);
     }
 
     public async Task<double> GetConversionRate(string fromCurrency, string toCurrency)
     {
-        if (string.IsNullOrWhiteSpace(fromCurrency))
+        var from = CurrencyCode.Normalize(fromCurrency);
+        var to = CurrencyCode.Normalize(toCurrency);
+
+        if (string.IsNullOrWhiteSpace(from))
         {
             throw new ArgumentException("From currency is required.", nameof(fromCurrency));
         }
 
-        if (string.IsNullOrWhiteSpace(toCurrency))
+        if (string.IsNullOrWhiteSpace(to))
         {
             throw new ArgumentException("To currency is required.", nameof(toCurrency));
         }
-
-        var from = fromCurrency.Trim().ToUpperInvariant();
-        var to = toCurrency.Trim().ToUpperInvariant();
 
         if (string.Equals(from, to, StringComparison.Ordinal))
         {
@@ -58,26 +61,13 @@ internal class CurrencyConverter : ICurrencyConverter
 
                 if (!response.IsSuccessStatusCode)
                 {
-                    // #region agent log
-                    try
-                    {
-                        var snippet = content.Length > 240 ? content[..240] : content;
-                        System.IO.File.AppendAllText(
-                            "/opt/cursor/logs/debug.log",
-                            JsonSerializer.Serialize(new
-                            {
-                                hypothesisId = "H2",
-                                location = "ICurrencyConverter.cs:GetConversionRate",
-                                message = "Frankfurter non-success",
-                                data = new { from, to, status = (int)response.StatusCode, bodySnippet = snippet },
-                                timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
-                            }) + "\n");
-                    }
-                    catch
-                    {
-                        /* ignore debug log I/O errors */
-                    }
-                    // #endregion
+                    var snippet = content.Length > 240 ? content[..240] : content;
+                    _logger.LogWarning(
+                        "Frankfurter non-success when loading rates for base {From} (target {To}): HTTP {Status} body: {BodySnippet}",
+                        from,
+                        to,
+                        (int)response.StatusCode,
+                        snippet);
 
                     throw new InvalidOperationException(
                         $"Frankfurter HTTP {(int)response.StatusCode} when loading rates for base {from}.");
@@ -116,25 +106,11 @@ internal class CurrencyConverter : ICurrencyConverter
             return rate;
         }
 
-        // #region agent log
-        try
-        {
-            System.IO.File.AppendAllText(
-                "/opt/cursor/logs/debug.log",
-                JsonSerializer.Serialize(new
-                {
-                    hypothesisId = "H2b",
-                    location = "ICurrencyConverter.cs:GetConversionRate",
-                    message = "Target currency missing in rates table",
-                    data = new { from, to, rateKeyCount = ratesTable.Count },
-                    timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
-                }) + "\n");
-        }
-        catch
-        {
-            /* ignore */
-        }
-        // #endregion
+        _logger.LogWarning(
+            "Target currency {To} missing in Frankfurter rate table for base {From} ({RateCount} keys).",
+            to,
+            from,
+            ratesTable.Count);
 
         throw new InvalidOperationException($"Unable to get conversion rate from {from} to {to}.");
     }

--- a/back/Features/Shared/Currency/CurrencyCode.cs
+++ b/back/Features/Shared/Currency/CurrencyCode.cs
@@ -1,0 +1,51 @@
+namespace PaintingProjectsManagement.Features.Currency;
+
+/// <summary>
+/// Normalizes currency codes from query strings, UI, or legacy DB values (BOM, zero-width chars, "EURO", etc.).
+/// </summary>
+public static class CurrencyCode
+{
+    public static string Normalize(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return string.Empty;
+        }
+
+        Span<char> buf = stackalloc char[3];
+        var n = 0;
+        foreach (var ch in raw.AsSpan().Trim())
+        {
+            if (ch is '\uFEFF' or '\u200B' or '\u200C' or '\u200D')
+            {
+                continue;
+            }
+
+            if (n >= 3)
+            {
+                break;
+            }
+
+            if (ch is >= 'A' and <= 'Z')
+            {
+                buf[n++] = ch;
+            }
+            else if (ch is >= 'a' and <= 'z')
+            {
+                buf[n++] = (char)(ch - 32);
+            }
+        }
+
+        if (n == 3)
+        {
+            return new string(buf);
+        }
+
+        if (n > 0)
+        {
+            return new string(buf[..n]);
+        }
+
+        return raw.Trim().ToUpperInvariant();
+    }
+}

--- a/back/Features/Shared/Testing/Placeholder_Tests.cs
+++ b/back/Features/Shared/Testing/Placeholder_Tests.cs
@@ -1,9 +1,1 @@
 namespace PaintingProjectsManagement.Testing.Core;
-
-public class Placeholder_Tests
-{
-    [TUnit.Core.Test]
-    public void Placeholder_Test_Passes()
-    {
-    }
-}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a dedicated `GET /projects/{projectId}/costs` endpoint so `GetProjectDetails` no longer recalculates costs on every request
- update the Blazor projects UI to open a costs dialog that loads project costs lazily on demand and re-fetches only when the currency changes
- add focused tests for the new costs endpoint and correct the cost DTO mapping to return the project id
- clean up the shared test helper project so the Microsoft Testing Platform runner can execute project tests normally in this environment
- retry transient currency API failures and return an explicit API error for project cost recalculation failures instead of a fake zero-cost success payload
- keep the current dialog values visible in Blazor and show a warning/snackbar when currency recalculation fails

## Testing
- `dotnet build Features/Modules/Projects/UI/UI/PaintingProjectsManagement.Features.Projects.UI.csproj`
- `dotnet build Application/UI/PaintingProjectsManagement.UI.csproj`
- `dotnet build Features/Modules/Projects/Web/Web/PaintingProjectsManagement.Features.Projects.Web.csproj`
- `dotnet test --project Features/Modules/Projects/Web/Web.Tests/PaintingProjectsManagement.Features.Projects.Web.Tests.csproj --treenode-filter "/*/*/*/*/Get Project Costs Tests|/*/*/*/*/Get Project Details Tests"`
- `dotnet run --project Aspire/AppHost/PaintingProjectsManagement.AppHost.csproj -- --allow-unsecured-transport`
- attempted fresh manual UI re-verification after the last error-handling change, but the restarted Blazor app instance served `_framework/blazor.boot.json` as 404 and could not initialize a clean browser session; focused automated tests remained green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca689bf1-21c8-48b0-82ec-0dd9aaf09911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca689bf1-21c8-48b0-82ec-0dd9aaf09911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

